### PR TITLE
Fix type error with pixel test percentage

### DIFF
--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -295,7 +295,7 @@ class Empire {
         $this->adSlotsPrefillEnabled = get_option( 'empire::ad_slots_prefill_enabled' );
         $this->cmp = get_option( 'empire::cmp' );
         $this->oneTrustId = get_option( 'empire::one_trust_id' );
-        $this->empirePixelTestPercent = get_option( 'empire::percent_test' );
+        $this->empirePixelTestPercent = intval( get_option( 'empire::percent_test' ) );
         $this->empirePixelTestValue = get_option( 'empire::test_value' );
 
         $this->connatixEnabled = get_option( 'empire::connatix_enabled' );


### PR DESCRIPTION
* ensure that it is stored as an integer even when empty

This error was manifesting in the GraphQL endpoint as:

```
Return value of Empire\\Empire::getEmpirePixelTestPercent() must be of the type int, string returned
```