### PR TITLE
SWP: New Blank Page

### DIFF
--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -89,7 +89,7 @@ class PageInjection {
                             return $content;
                         }
 
-                        if ( ! apply_filters( 'organic::eligible-for-ads', $this->organic->eligibleForAds( $content ) ) ) {
+                        if ( ! apply_filters( 'organic_eligible_for_ads', $this->organic->eligibleForAds( $content ) ) ) {
                             return $content;
                         }
 
@@ -194,7 +194,7 @@ class PageInjection {
         }
 
         // Checks if this is a page using a template without ads.
-        if ( ! apply_filters( 'organic::eligible-for-ads', true ) ) {
+        if ( ! apply_filters( 'organic_eligible_for_ads', true ) ) {
             return;
         }
 

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -89,7 +89,7 @@ class PageInjection {
                             return $content;
                         }
 
-                        if ( ! apply_filters('organic::eligible-for-ads', $this->organic->eligibleForAds( $content ) ) ) {
+                        if ( ! apply_filters( 'organic::eligible-for-ads', $this->organic->eligibleForAds( $content ) ) ) {
                             return $content;
                         }
 
@@ -194,7 +194,7 @@ class PageInjection {
         }
 
         // Checks if this is a page using a template without ads.
-        if( ! apply_filters( 'organic::eligible-for-ads', true ) ) {
+        if ( ! apply_filters( 'organic::eligible-for-ads', true ) ) {
             return;
         }
 

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -89,7 +89,7 @@ class PageInjection {
                             return $content;
                         }
 
-                        if ( ! $this->organic->eligibleForAds( $content ) ) {
+                        if ( ! apply_filters('organic::eligible-for-ads', $this->organic->eligibleForAds( $content ) ) ) {
                             return $content;
                         }
 
@@ -190,6 +190,11 @@ class PageInjection {
     public function injectPixel() {
         // If Organic isn't enabled, then don't bother injecting anything
         if ( ! $this->organic->isEnabled() ) {
+            return;
+        }
+
+        // Checks if this is a page using a template without ads.
+        if( ! apply_filters( 'organic::eligible-for-ads', true ) ) {
             return;
         }
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ of the Synchronization to Organic Platform.
 * `organic_post_publish_date` - transform the publish date of the post
 * `organic_post_modified_date` - transform the modified date of the post
 * `organic_post_authors` - accepts array with one author info based on $post->post_author data and $post->ID; expects an array of dicts with 'externalId' and 'name' keys
+* `organic_eligible_for_ads` - enable or disable ads injection, overlapping plugin settings
 
 Example Filter Implementations:
 ```php


### PR DESCRIPTION
This change will not affect the production environment since the WordPress `apply_filters` function returns the 2nd parameter value when there isn't any place calling the filter. 
I'm implementing a new page template on the Empire theme where should not inject ads. So, the theme will use this filter to overlay the plugin ads injection settings on this template. 