### PR TITLE
Expose the raw Ads rules to GraphQL

### DIFF
--- a/Organic/GraphQL.php
+++ b/Organic/GraphQL.php
@@ -112,6 +112,10 @@ class GraphQL {
                     'type' => 'String',
                     'description' => $this->organic->t( 'Site ID for this site within Organic', 'organic' ),
                 ],
+                'adsRawData' => [
+                    'type' => 'String',
+                    'description' => $this->organic->t( 'JSON of the raw Ads rules', 'organic' ),
+                ],
             ],
         ];
     }
@@ -147,6 +151,8 @@ class GraphQL {
                         'preloadContainersConfig' => $this->organic->getAdsConfig()->forPlacement ?
                             json_encode( $this->organic->getAdsConfig()->forPlacement ) : '[]',
                         'siteId' => $this->organic->getSiteId(),
+                        'adsRawData'=>$this->organic->getAdsConfig()->raw ?
+                            json_encode( $this->organic->getAdsConfig()->raw ) : '[]'
                     ];
                 },
             ]

--- a/Organic/GraphQL.php
+++ b/Organic/GraphQL.php
@@ -151,8 +151,8 @@ class GraphQL {
                         'preloadContainersConfig' => $this->organic->getAdsConfig()->forPlacement ?
                             json_encode( $this->organic->getAdsConfig()->forPlacement ) : '[]',
                         'siteId' => $this->organic->getSiteId(),
-                        'adsRawData'=>$this->organic->getAdsConfig()->raw ?
-                            json_encode( $this->organic->getAdsConfig()->raw ) : '[]'
+                        'adsRawData' => $this->organic->getAdsConfig()->raw ?
+                            json_encode( $this->organic->getAdsConfig()->raw ) : '[]',
                     ];
                 },
             ]


### PR DESCRIPTION
I add 1 more field to expose the raw rules to GraphQL

Example results:
<img width="1865" alt="image" src="https://user-images.githubusercontent.com/60590068/157368442-a1beba63-7d60-4543-b52a-bda63fa43a8f.png">
<img width="710" alt="image" src="https://user-images.githubusercontent.com/60590068/157368389-f31433b5-5e1b-4f74-aa1e-e04c1eb1ab5b.png">
