### PR TITLE
EP-1937: Adding functionality to initialize AdThrive code injection, if in the correct bucket. 

### DIFF
--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -2,6 +2,7 @@
 
 
 namespace Organic;
+
 /**
  * Handles adding data into the various pages on the website based on the selected
  * configuration.
@@ -315,11 +316,11 @@ class PageInjection {
                     <?php } ?>
                         }
 
-                <?php if ( $this->organic->useAdsSlotsPrefill() ) { ?>
+                    <?php if ( $this->organic->useAdsSlotsPrefill() ) { ?>
                         loadAds();
-                <?php } else { ?>
+                    <?php } else { ?>
                         setTimeout(loadAds, loadDelay);
-                <?php } ?>
+                    <?php } ?>
                     })();
                 }
             </script>

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -2,7 +2,6 @@
 
 
 namespace Organic;
-
 /**
  * Handles adding data into the various pages on the website based on the selected
  * configuration.
@@ -255,63 +254,74 @@ class PageInjection {
                 });
                 <?php } ?></script>
             <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
-            <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
             <script>
-                var googletag = googletag || {};
-                var pbjs = pbjs || {};
+                /* The below condition is a very specific case setup for Ads AB testing on realmenrealstyle.com */
+                if (
+                    window.organicTestKey.indexOf('organic_adthrive') > -1 &&
+                    BVTests.getValue(window.organicTestKey) === 'control'
+                ) {
+                    if ( window.loadAdThrive && typeof window.loadAdThrive === 'function' )
+                        window.loadAdThrive(window, document);
+                } else {
+                    /* Loading GPT script */
+                    utils.loadScript(document, 'gpt', 'https://securepubads.g.doubleclick.net/tag/js/gpt.js', null, {async:true});
 
-                /* TrackADM Config - to be phased out */
-                window.__trackadm_usp_cookie = 'ne-opt-out';
-                window.tadmPageId = '<?php echo $gamPageId; ?>';
-                window.tadmKeywords = '<?php echo $keywordString; ?>';
-                window.tadmSection = '<?php echo $categoryString; ?>';
-                window.trackADMData = {
-                    tests: BVTests.getTargetingValue()
-                };
+                    var googletag = googletag || {};
+                    var pbjs = pbjs || {};
 
-                /* Organic Config - to be phased in */
-                window.__organic_usp_cookie = 'ne-opt-out';
-                window.empire = window.empire || {};
-                window.empire.apps = window.empire.apps || {};
-                window.empire.apps.ads = window.empire.apps.ads || {};
-                window.empire.apps.ads.config = window.empire.apps.ads.config || {};
-            <?php if ( $this->organic->useInjectedAdsConfig() ) { ?>
+                    /* TrackADM Config - to be phased out */
+                    window.__trackadm_usp_cookie = 'ne-opt-out';
+                    window.tadmPageId = '<?php echo $gamPageId; ?>';
+                    window.tadmKeywords = '<?php echo $keywordString; ?>';
+                    window.tadmSection = '<?php echo $categoryString; ?>';
+                    window.trackADMData = {
+                        tests: BVTests.getTargetingValue()
+                    };
 
-                window.empire.apps.ads.config.siteDomain = "<?php echo $this->organic->siteDomain; ?>";
-                window.empire.apps.ads.config.adConfig = <?php echo json_encode( $this->organic->getAdsConfig()->raw ); ?>;
-            <?php } ?>
+                    /* Organic Config - to be phased in */
+                    window.__organic_usp_cookie = 'ne-opt-out';
+                    window.empire = window.empire || {};
+                    window.empire.apps = window.empire.apps || {};
+                    window.empire.apps.ads = window.empire.apps.ads || {};
+                    window.empire.apps.ads.config = window.empire.apps.ads.config || {};
+                <?php if ( $this->organic->useInjectedAdsConfig() ) { ?>
 
-                window.empire.apps.ads.targeting = {
-                    pageId: '<?php echo $gamPageId; ?>',
-                    externalId: '<?php echo $gamExternalId; ?>',
-                    keywords: '<?php echo $keywordString; ?>',
-                    disableKeywordReporting: false,
-                    section: '<?php echo $categoryString; ?>',
-                    disableSectionReporting: false,
-                    tests: BVTests.getTargetingValue(),
-                }
-
-                googletag.cmd = googletag.cmd || [];
-                pbjs.que = pbjs.que || [];
-
-                var loadDelay = 2000;
-
-                (function() {
-                    function loadAds() {
-                        utils.loadScript(document, 'prebid-library', "<?php echo $this->organic->getAdsConfig()->getPrebidBuildUrl(); ?>");
-                <?php if ( $this->organic->getSiteId() ) { /* This only works if Site ID is set up */ ?>
-                    utils.loadScript(document, 'organic-sdk', "<?php echo $this->organic->sdk->getSdkUrl(); ?>");
-                <?php } else { ?>
-                        utils.loadScript(document, 'track-adm-adx-pixel', "<?php echo $this->organic->getPixelPublishedUrl(); ?>");
+                    window.empire.apps.ads.config.siteDomain = "<?php echo $this->organic->siteDomain; ?>";
+                    window.empire.apps.ads.config.adConfig = <?php echo json_encode( $this->organic->getAdsConfig()->raw ); ?>;
                 <?php } ?>
+
+                    window.empire.apps.ads.targeting = {
+                        pageId: '<?php echo $gamPageId; ?>',
+                        externalId: '<?php echo $gamExternalId; ?>',
+                        keywords: '<?php echo $keywordString; ?>',
+                        disableKeywordReporting: false,
+                        section: '<?php echo $categoryString; ?>',
+                        disableSectionReporting: false,
+                        tests: BVTests.getTargetingValue(),
                     }
 
-              <?php if ( $this->organic->useAdsSlotsPrefill() ) { ?>
-                    loadAds();
-              <?php } else { ?>
-                    setTimeout(loadAds, loadDelay);
-              <?php } ?>
-                })();
+                    googletag.cmd = googletag.cmd || [];
+                    pbjs.que = pbjs.que || [];
+
+                    var loadDelay = 2000;
+
+                    (function() {
+                        function loadAds() {
+                            utils.loadScript(document, 'prebid-library', "<?php echo $this->organic->getAdsConfig()->getPrebidBuildUrl(); ?>");
+                    <?php if ( $this->organic->getSiteId() ) { /* This only works if Site ID is set up */ ?>
+                        utils.loadScript(document, 'organic-sdk', "<?php echo $this->organic->sdk->getSdkUrl(); ?>");
+                    <?php } else { ?>
+                            utils.loadScript(document, 'track-adm-adx-pixel', "<?php echo $this->organic->getPixelPublishedUrl(); ?>");
+                    <?php } ?>
+                        }
+
+                <?php if ( $this->organic->useAdsSlotsPrefill() ) { ?>
+                        loadAds();
+                <?php } else { ?>
+                        setTimeout(loadAds, loadDelay);
+                <?php } ?>
+                    })();
+                }
             </script>
             <?php
         }

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -256,7 +256,7 @@ class PageInjection {
                 <?php } ?></script>
             <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
             <script>
-                /* The below condition is a very specific case setup for Ads AB testing on realmenrealstyle.com */
+                /* The below condition is a very specific case setup for Ads AB testing */
                 if (
                     window.organicTestKey.indexOf('organic_adthrive') > -1 &&
                     BVTests.getValue(window.organicTestKey) === 'control'


### PR DESCRIPTION
**Change Request:**
1. Adding functionality to AB test against AdThrive plugin. 
2. Based on the bucketing values, the plugin should initialize AdThrive script load or load Organic Ad scripts.
3. AB testing key should contain `%organic_adthrive%` for this to run else, Organic scripts will load as usual.
4. Dynamically loading `gpt.js` to prevent multiple google tag script load while testing with other Ad Wordpress plugins.

**Dependencies:**
1. AdThrive Plugin needs to be updated. IIFE that loads ad scripts in file `adthrive-ads/components/ads/partials/ads.php` need to declared as a function. example:
```
<script>
window.loadAdThrive = (function(w, d) {
	w.adthrive = w.adthrive || {};
	w.adthrive.cmd = w.adthrive.cmd || [];
	w.adthrive.plugin = 'adthrive-ads-<?php echo esc_js( ADTHRIVE_ADS_VERSION ); ?>';
	w.adthrive.host = 'ads.adthrive.com';
	w.adthrive.integration = 'plugin';

	var commitParam = (w.adthriveCLS && w.adthriveCLS.bucket !== 'prod' && w.adthriveCLS.branch) ? '&commit=' + w.adthriveCLS.branch : '';

	var s = d.createElement('script');
	s.async = true;
	s.referrerpolicy='no-referrer-when-downgrade';
	s.src = 'https://' + w.adthrive.host + '/sites/<?php esc_attr_e( $data['site_id'] ); ?>/ads.min.js?referrer=' + w.encodeURIComponent(w.location.href) + commitParam + '&cb=' + (Math.floor(Math.random() * 100) + 1) + '<?php echo 'true' === $data['plugin_debug'] ? '&debug=true' : ''; ?>';
	var n = d.getElementsByTagName('script')[0];
	n.parentNode.insertBefore(s, n);
});
</script>
```

**Testing Flow:**
- [ ] Load Organic plugin on one of the solutions sites.
- [ ] check to see the ads load fine along with google publisher tags. You can check it by running `googletag.openConsole()`  in the console.
- [ ] Add AdThrive Plugin https://wordpress.org/plugins/adthrive-ads/ , update the `Site Id` value to `591b55faa29bbe3a6f50b09c`
- [ ] make updates to AdThrive as described in Dependency 1
- [ ] set `Key-Value for Split Test:` in Organic Plugin settings and use a string which contains `organic_adthrive` substring. 
- [ ] reload the page, either of the js scripts should load based on testing bucket. For AdThrive, `ads.min.js` should load
- [ ] confirm if the correct Google Publisher Tags are loaded using `googletag.openConsole()`

