### PR TITLE
Connatix Injector fails in some old WP instances

### DIFF
--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -166,13 +166,20 @@ class PageInjection {
             return $content;
         }
 
-        // Figure out if there is a paragraph to inject after
+        // Figure out if there is a paragraph to inject after. If it doesn't exist (some legacy Wordpress's) then
+        // use a SPAN instead.
         $injectionPoint = strpos( $content, '</p>' );
+        $injectionPointOffset = 4;
         if ( $injectionPoint === false ) {
-            return $content;
+            $injectionPoint = strpos( $content, '</span>' );
+            $injectionPointOffset = 7;
+            if ( $injectionPoint === false ) {
+                return $content;
+            }
         }
+
         // Adjust for the length of </p>
-        $injectionPoint += 4;
+        $injectionPoint += $injectionPointOffset;
 
         $this->connatixInjected = true;
 


### PR DESCRIPTION
* `if the search for a <p> tag fails, find a <span> instead`