### PR TITLE
Adding manual sync method for sites without cron

### DIFF
--- a/Organic/AdminSettings.php
+++ b/Organic/AdminSettings.php
@@ -37,6 +37,8 @@ class AdminSettings {
             } else if ( isset( $_POST['organic_post_types'] ) ) {
                 $this->organic->updateOption( 'organic::post_types', $_POST['organic_post_types'], false );
                 $this->organic->setPostTypes( $_POST['organic_post_types'] );
+            } else if ( isset( $_POST['organic_content_sync'] ) ) {
+                $this->organic->syncContent( 100 );
             } else {
                 $this->organic->updateOption( 'organic::enabled', isset( $_POST['organic_enabled'] ) ? true : false, false );
                 $this->organic->updateOption( 'organic::percent_test', $_POST['organic_percent'], false );
@@ -296,6 +298,10 @@ class AdminSettings {
                 ?>
                 </ul>
                 <p><input type="submit" value="Save" />
+            </form>
+            <form method="post">
+                <input type="hidden" name="organic_content_sync" value="1" />
+                <input type="submit" value="Sync Content Batch" />
             </form>
         </div>
             <?php

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -914,12 +914,11 @@ class Organic {
      *
      * Works in batches of 1000 to minimize load issues
      *
+     * @param int $max_to_sync Number of posts to attempt to sync
      * @return int Number of posts synchronized
      * @throws Exception if posts have invalid published or modified dates
      */
-    public function syncContent() : int {
-        $max_to_sync = 1000;
-
+    public function syncContent( $max_to_sync = 1000 ) : int {
         // First go through ones that have never been sync-ed
         $query = $this->buildQueryNeverSyncedPosts( $max_to_sync );
         $updated = $this->_syncPosts( $query->posts );


### PR DESCRIPTION
This is intended to be used only for the initial synchronization batch since some sites are intentionally configured with no CRON mechanism to run in the background.