### PR TITLE
Removing non-backward compatible PHP annotations

### DIFF
--- a/Organic/AdConfigSyncCommand.php
+++ b/Organic/AdConfigSyncCommand.php
@@ -8,7 +8,7 @@ class AdConfigSyncCommand {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;

--- a/Organic/AdminNotice.php
+++ b/Organic/AdminNotice.php
@@ -22,11 +22,10 @@ class AdminNotice {
     public static function showNotices() {
         foreach ( static::$notices as $notice ) {
             $is_dismissible = $notice['is_dismissible'] ? 'is-dismissible' : '';
-            $div = <<<DIV
-            <div class="notice notice-{$notice['type']} {$is_dismissible}">
+            $div = "
+            <div class=\"notice notice-{$notice['type']} {$is_dismissible}'>
             <p>{$notice['message']}</p>
-            </div>
-            DIV;
+            </div>";
             echo $div;
         }
     }

--- a/Organic/AdminSettings.php
+++ b/Organic/AdminSettings.php
@@ -101,12 +101,10 @@ class AdminSettings {
 
         if ( ! $fbia->isFacebookPluginConfigured() ) {
             AdminNotice::warning(
-                <<< EOM
-                Facebook instant articles are enabled for this site, but facebook plugin has
-                its own ads configuration.
-                <br/>
-                Turn it off by setting 'Ad type' to 'none' on the plugin settings page.
-                EOM
+                "Facebook instant articles are enabled for this site, but facebook plugin has its own ads 
+                     configuration.
+                     <br/>
+                     Turn it off by setting 'Ad type' to 'none' on the plugin settings page."
             );
         }
 

--- a/Organic/AdsConfig.php
+++ b/Organic/AdsConfig.php
@@ -14,7 +14,7 @@ class AdsConfig extends BaseConfig {
      *  string value
      *  (optional) array placementKeys
      */
-    public array $adRules;
+    public $adRules;
 
     /**
      * Map (key -> Placement) of Placements returned from Organic Platform API
@@ -23,10 +23,10 @@ class AdsConfig extends BaseConfig {
      *  int limit
      *  string relative
      */
-    public array $forPlacement;
+    public $forPlacement;
 
-    private string $fallbackUrl;
-    private string $prebidUrl;
+    private $fallbackUrl;
+    private $prebidUrl;
 
     public function __construct( array $raw ) {
         parent::__construct( $raw );

--- a/Organic/AdsInjector.php
+++ b/Organic/AdsInjector.php
@@ -9,7 +9,10 @@ use DOMXPath;
 
 class AdsInjector {
     private $fragmentBuilder;
-    private ?\FluentDOM\Xpath\Transformer $xpathTransformer = null;
+    /**
+     * @var null|\FluentDOM\Xpath\Transformer
+     */
+    private $xpathTransformer = null;
 
     public static function loadElement( $html, $type = 'html5' ) {
         $document = \FluentDOM::load(
@@ -17,7 +20,7 @@ class AdsInjector {
             $type,
             [
                 \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true,
-            ],
+            ]
         );
         return $document->getElementsByTagName( 'html' )->item( 0 );
     }

--- a/Organic/AdsTxtSyncCommand.php
+++ b/Organic/AdsTxtSyncCommand.php
@@ -8,7 +8,7 @@ class AdsTxtSyncCommand {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;

--- a/Organic/AmpAdsInjector.php
+++ b/Organic/AmpAdsInjector.php
@@ -3,9 +3,9 @@
 namespace Organic;
 
 class AmpAdsInjector extends \AMP_Base_Sanitizer {
-    private Organic $organic;
-    private AdsInjector $adsInjector;
-    private bool $connatixInjected = false;
+    private $organic;
+    private $adsInjector;
+    private $connatixInjected = false;
     private $targeting = null;
 
     public function sanitize() {
@@ -40,11 +40,9 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
         foreach ( $ampConfig->forPlacement as $key => $amp ) {
             $placement = $adsConfig->forPlacement[ $key ];
 
-            [
-                'selectors' => $selectors,
-                'limit' => $limit,
-                'relative' => $relative,
-            ] = $placement;
+            $selectors = $placement['selectors'];
+            $limit = $placement['limit'];
+            $relative = $placement['relative'];
 
             // certain placement is blocked
             if ( $rule && in_array( $key, $blockedKeys ) ) {
@@ -72,15 +70,14 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
         }
 
         $psid = $this->organic->getConnatixPlayspaceId();
-        $player = <<<HTML
+        $player = "
             <amp-connatix-player
-                data-player-id="ps_$psid"
-                layout="responsive"
-                width="16"
-                height="9"
+                data-player-id=\"ps_$psid\"
+                layout=\"responsive\"
+                width=\"16\"
+                height=\"9\"
             >
-            </amp-connatix-player>
-        HTML;
+            </amp-connatix-player>";
 
         $this->adsInjector->injectAds(
             $player,

--- a/Organic/AmpConfig.php
+++ b/Organic/AmpConfig.php
@@ -9,6 +9,8 @@ class AmpConfig extends BaseConfig {
      * Map (key -> amp) of amps for placements returned from Organic Platform API
      * Each amp must contain at least:
      *  string html
+     *
+     * @var array
      */
-    public array $forPlacement;
+    public $forPlacement;
 }

--- a/Organic/BaseConfig.php
+++ b/Organic/BaseConfig.php
@@ -6,13 +6,17 @@ class BaseConfig {
 
     /**
      * Map (key -> config-for-placement) of configs for Placements
+     *
+     * @var array
      */
-    public array $forPlacement;
+    public $forPlacement;
 
     /**
      * Raw Config returned from Organic Platform API
+     *
+     * @var array
      */
-    public array $raw;
+    public $raw;
 
     public function __construct( array $raw ) {
         if ( empty( $raw ) ) {

--- a/Organic/CCPAPage.php
+++ b/Organic/CCPAPage.php
@@ -15,7 +15,7 @@ class CCPAPage {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;

--- a/Organic/ContentIdMapSyncCommand.php
+++ b/Organic/ContentIdMapSyncCommand.php
@@ -8,7 +8,7 @@ class ContentIdMapSyncCommand {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;

--- a/Organic/ContentSyncCommand.php
+++ b/Organic/ContentSyncCommand.php
@@ -8,7 +8,7 @@ class ContentSyncCommand {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;
@@ -71,7 +71,7 @@ class ContentSyncCommand {
             $updated = $this->organic->fullResyncContent(
                 (int) ( $opts['batch-size'] ?? 100 ),
                 (int) ( $opts['start-from'] ?? 0 ),
-                (int) ( $opts['sleep-between'] ?? 1 ),
+                (int) ( $opts['sleep-between'] ?? 1 )
             );
             $this->organic->info( 'Organic Sync stats', [ 'updated' => $updated ] );
             return;

--- a/Organic/Environment.php
+++ b/Organic/Environment.php
@@ -3,8 +3,8 @@
 namespace Organic;
 
 class Environment {
-    public const LOCAL = 'LOCAL';
-    public const DEVELOPMENT = 'DEVELOPMENT';
-    public const STAGING = 'STAGING';
-    public const PRODUCTION = 'PRODUCTION';
+    const LOCAL = 'LOCAL';
+    const DEVELOPMENT = 'DEVELOPMENT';
+    const STAGING = 'STAGING';
+    const PRODUCTION = 'PRODUCTION';
 }

--- a/Organic/FbiaAdsInjector.php
+++ b/Organic/FbiaAdsInjector.php
@@ -3,13 +3,19 @@
 namespace Organic;
 
 use FluentDOM\DOM\Document;
-use FluentDOM\DOM\Element;
 
 class FbiaAdsInjector {
     const ALL_KEYS = 'ALL_KEYS';
 
-    private FbiaConfig $config;
-    private Organic $organic;
+    /**
+     * @var FbiaConfig
+     */
+    private $config;
+
+    /**
+     * @var Organic
+     */
+    private $organic;
     private $_targeting;
     private $_blockedKeys;
 
@@ -30,7 +36,7 @@ class FbiaAdsInjector {
         $dom = \FluentDOM::load(
             $html,
             'html5',
-            [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ],
+            [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ]
         );
         $this->injectMeta( $dom );
 
@@ -65,7 +71,7 @@ class FbiaAdsInjector {
         $meta = $dom->createElement(
             'meta',
             '',
-            $attrs,
+            $attrs
         );
 
         $dom->getElementsByTagName( 'head' )->item( 0 )->appendChild(
@@ -87,7 +93,7 @@ class FbiaAdsInjector {
 
         $node = AdsInjector::copyFragment(
             $dom,
-            AdsInjector::loadElement( $html ),
+            AdsInjector::loadElement( $html )
         );
 
         $dom->getElementsByTagName( 'header' )->item( 0 )->appendChild( $node );
@@ -115,7 +121,7 @@ class FbiaAdsInjector {
                     $html,
                     $placement['relative'],
                     $placement['selectors'],
-                    $placement['limit'],
+                    $placement['limit']
                 );
             } catch ( \Exception $e ) {
                 \Organic\Organic::captureException( $e );

--- a/Organic/FbiaConfig.php
+++ b/Organic/FbiaConfig.php
@@ -19,9 +19,20 @@ class FbiaConfig extends BaseConfig {
         'placements' => [],
     ];
 
-    public int $mode;
-    public bool $enabled;
-    public string $adDensity = self::AD_DENSITY_DEFAULT;
+    /**
+     * @var int
+     */
+    public $mode;
+
+    /**
+     * @var bool
+     */
+    public $enabled;
+
+    /**
+     * @var string
+     */
+    public $adDensity = self::AD_DENSITY_DEFAULT;
 
     public function __construct( array $raw ) {
         $config = array_merge( self::DEFAULTS, $raw );

--- a/Organic/FbiaProxy.php
+++ b/Organic/FbiaProxy.php
@@ -4,7 +4,11 @@ namespace Organic;
 
 class FbiaProxy {
     private $article;
-    private FbiaAdsInjector $injector;
+
+    /**
+     * @var FbiaAdsInjector
+     */
+    private $injector;
 
     public function __construct( $article, $organic ) {
         $this->article = $article;

--- a/Organic/GraphQL.php
+++ b/Organic/GraphQL.php
@@ -10,7 +10,7 @@ class GraphQL {
     /**
      * @var Organic
      */
-    protected Organic $organic;
+    protected $organic;
 
     public function __construct( Organic $organic ) {
         $this->organic = $organic;
@@ -170,13 +170,8 @@ class GraphQL {
                 'type' => 'String',
                 'description' => __( 'ArticleID for GAM for Revenue Attribution', 'organic' ),
                 'resolve' => function() {
-                    [
-                        'keywords' => $keywords,
-                        'category' => $category,
-                        'gamPageId' => $gamPageId,
-                        'gamExternalId' => $gamExternalId,
-                    ] = $this->organic->getTargeting();
-
+                    $targeting = $this->organic->getTargeting();
+                    $gamPageId = $targeting['gamPageId'];
                     return $gamPageId;
                 },
             ]

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -103,22 +103,22 @@ class Organic {
     /**
      * @var array Configuration for AMP
      */
-    private ?AmpConfig $ampConfig = null;
+    private $ampConfig = null;
 
     /**
      * @var array Configuration for Prefill
      */
-    private ?PrefillConfig $prefillConfig = null;
+    private $prefillConfig = null;
 
     /**
      * @var AdsConfig Configuration for Ads
      */
-    private ?AdsConfig $adsConfig = null;
+    private $adsConfig = null;
 
     /**
      * @var FbiaConfig Configuration for FBIA
      */
-    private ?FbiaConfig $fbiaConfig = null;
+    private $fbiaConfig = null;
 
     /**
      * List of Post Types that we are synchronizing with Organic Platform

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -228,7 +228,7 @@ class Organic {
      * @param $apiUrl string|null
      * @param string|null $cdnUrl
      */
-    public function init( ?string $apiUrl = null, ?string $cdnUrl = null ) {
+    public function init( $apiUrl = null, $cdnUrl = null ) {
         $this->sdkKey = $this->getOption( 'organic::sdk_key' );
         $this->siteId = $this->getOption( 'organic::site_id' );
         $this->siteDomain = $this->getOption( 'organic::site_domain' );
@@ -375,7 +375,11 @@ class Organic {
         return $this->isEnabled() && $this->adSlotsPrefillEnabled;
     }
 
-    public function eligibleForAds( ?string $content = null ) {
+    /**
+     * @param $content string|null
+     * @return bool|int
+     */
+    public function eligibleForAds( $content = null ) {
         global $wp_query;
 
         if ( is_admin() || wp_doing_ajax() ) {
@@ -809,7 +813,7 @@ class Organic {
                 $rich_content_images,
                 $rich_content_videos,
                 $rich_content_embeds,
-                $campaign_asset_guid,
+                $campaign_asset_guid
             );
         } catch ( \Exception $e ) {
             // We should manually let Sentry know about this, since theoretically the API
@@ -902,7 +906,7 @@ class Organic {
                     'key' => SYNC_META_KEY,
                     'compare' => 'NOT EXISTS',
                 ),
-            ),
+            )
         );
     }
 
@@ -923,7 +927,7 @@ class Organic {
                     'value' => 'synced',
                     'compare' => '!=',
                 ),
-            ),
+            )
         );
     }
 
@@ -1055,8 +1059,8 @@ class Organic {
                 "SELECT pm.meta_id AS id, pm.post_id, pm.meta_value AS gam_id
                 FROM {$wpdb->postmeta} pm
                 WHERE pm.meta_key = %s",
-                GAM_ID_META_KEY,
-            ),
+                GAM_ID_META_KEY
+            )
         );
         $this->debug( 'Found mapped gamIds in DB: ' . count( $metas ) );
         foreach ( $metas as $meta ) {
@@ -1198,63 +1202,63 @@ class Organic {
     /**
      * @return string|null
      */
-    public function getPixelId(): ?string {
+    public function getPixelId() {
         return $this->pixelId;
     }
 
     /**
      * @return string|null
      */
-    public function getPixelPublishedUrl(): ?string {
+    public function getPixelPublishedUrl() {
         return $this->pixelPublishedUrl;
     }
 
     /**
      * @return string|null
      */
-    public function getPixelTestingUrl(): ?string {
+    public function getPixelTestingUrl() {
         return $this->pixelTestingUrl;
     }
 
     /**
      * @param int|null $pixelId
      */
-    public function setPixelId( ?int $pixelId ): void {
+    public function setPixelId( $pixelId ) {
         $this->pixelId = $pixelId;
     }
 
     /**
      * @param string|null $pixelPublishedUrl
      */
-    public function setPixelPublishedUrl( ?string $pixelPublishedUrl ): void {
+    public function setPixelPublishedUrl( $pixelPublishedUrl ) {
         $this->pixelPublishedUrl = $pixelPublishedUrl;
     }
 
     /**
      * @param string|null $pixelTestingUrl
      */
-    public function setPixelTestingUrl( ?string $pixelTestingUrl ): void {
+    public function setPixelTestingUrl( $pixelTestingUrl ) {
         $this->pixelTestingUrl = $pixelTestingUrl;
     }
 
     /**
      * @return string|null
      */
-    public function getSiteId(): ?string {
+    public function getSiteId() {
         return $this->siteId;
     }
 
     /**
      * @return string|null SDK Key (if set)
      */
-    public function getSdkKey(): ?string {
+    public function getSdkKey() {
         return $this->sdkKey;
     }
 
     /**
      * @return string|null
      */
-    public function getOrganicPixelTestValue(): ?string {
+    public function getOrganicPixelTestValue() {
         return $this->organicPixelTestValue;
     }
 

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -14,7 +14,7 @@ class PageInjection {
     /**
      * @var Organic
      */
-    private Organic $organic;
+    private $organic;
 
     /**
      * Tracker flag to ensure we don't inject multiple copies of the Connatix player. This has
@@ -89,7 +89,7 @@ class PageInjection {
                 $article = $ia_post->instant_article;
                 $ia_post->instant_article = new FbiaProxy(
                     $article,
-                    $this->organic,
+                    $this->organic
                 );
             }
         );
@@ -121,7 +121,7 @@ class PageInjection {
                         $prefillInjector = new PrefillAdsInjector(
                             $adsConfig,
                             $prefillConfig,
-                            $targeting,
+                            $targeting
                         );
 
                         try {
@@ -234,12 +234,11 @@ class PageInjection {
         if ( $this->organic->getPixelPublishedUrl() || $this->organic->getSiteId() ) {
             $categoryString = '';
             $keywordString = '';
-            [
-                'keywords' => $keywords,
-                'category' => $category,
-                'gamPageId' => $gamPageId,
-                'gamExternalId' => $gamExternalId,
-            ] = $this->organic->getTargeting();
+            $targeting = $this->organic->getTargeting();
+            $keywords = $targeting['keywords'];
+            $category = $targeting['category'];
+            $gamPageId = $targeting['gamPageId'];
+            $gamExternalId = $targeting['gamExternalId'];
 
             if ( ! is_null( $category ) ) {
                 $categoryString = $category->slug;

--- a/Organic/PrefillAdsInjector.php
+++ b/Organic/PrefillAdsInjector.php
@@ -3,8 +3,15 @@
 namespace Organic;
 
 class PrefillAdsInjector {
-    private AdsConfig $adsConfig;
-    private PrefillConfig $prefillConfig;
+    /**
+     * @var AdsConfig
+     */
+    private $adsConfig;
+
+    /**
+     * @var PrefillConfig
+     */
+    private $prefillConfig;
     private $targeting;
 
     public function __construct( AdsConfig $adsConfig, PrefillConfig $prefillConfig, $targeting ) {
@@ -17,7 +24,7 @@ class PrefillAdsInjector {
         $contentDom = \FluentDOM::load(
             $content,
             'html5',
-            [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ],
+            [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ]
         );
 
         $implementation = new \DOMImplementation();
@@ -30,7 +37,7 @@ class PrefillAdsInjector {
                 $document = \FluentDOM::load(
                     $html,
                     'html5',
-                    [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ],
+                    [ \FluentDOM\HTML5\Loader::DISABLE_HTML_NAMESPACE => true ]
                 );
                 return $document->getElementsByTagName( 'html' )->item( 0 );
             }
@@ -53,11 +60,9 @@ class PrefillAdsInjector {
 
             $placement = $this->adsConfig->forPlacement[ $key ];
 
-            [
-                'selectors' => $selectors,
-                'limit' => $limit,
-                'relative' => $relative,
-            ] = $placement;
+            $selectors = $placement['selectors'];
+            $limit = $placement['limit'];
+            $relative = $placement['relative'];
 
             $adContainer = $prefill['html'];
 

--- a/Organic/PrefillConfig.php
+++ b/Organic/PrefillConfig.php
@@ -8,6 +8,8 @@ class PrefillConfig extends BaseConfig {
      * Each prefill must contain at least:
      *  string html
      *  string css
+     *
+     * @var array
      */
-    public array $forPlacement;
+    public $forPlacement;
 }

--- a/Organic/SDK/OrganicSdk.php
+++ b/Organic/SDK/OrganicSdk.php
@@ -20,9 +20,9 @@ use RuntimeException;
  */
 class OrganicSdk {
 
-    public const DEFAULT_API_URL = 'https://api.organic.ly/graphql';
-    public const DEFAULT_ASSETS_URL = 'https://organiccdn.io/assets/';
-    public const FALLBACK_PREBID_BUILD = 'prebid5.13.0.js';
+    const DEFAULT_API_URL = 'https://api.organic.ly/graphql';
+    const DEFAULT_ASSETS_URL = 'https://organiccdn.io/assets/';
+    const FALLBACK_PREBID_BUILD = 'prebid5.13.0.js';
 
 
     /**
@@ -55,9 +55,9 @@ class OrganicSdk {
      */
     public function __construct(
         string $siteGuid,
-        ?string $token = null,
-        ?string $apiUrl = null,
-        ?string $cdnUrl = null
+        $token = null,
+        $apiUrl = null,
+        $cdnUrl = null
     ) {
         if ( ! $apiUrl ) {
             $apiUrl = self::DEFAULT_API_URL;
@@ -510,7 +510,7 @@ class OrganicSdk {
      *
      * @param string|null $token
      */
-    public function updateToken( ?string $token ) {
+    public function updateToken( $token ) {
         $params = array();
         if ( $token ) {
             $params['x-api-key'] = $token;

--- a/Organic/public.php
+++ b/Organic/public.php
@@ -28,7 +28,7 @@ function organic_get_all_campaign_assets(): array {
     return $result;
 }
 
-function organic_content_assign_campaign_asset( $post_id, ?string $campaign_asset_guid ): void {
+function organic_content_assign_campaign_asset( $post_id, $campaign_asset_guid ) {
     Organic::getInstance()->assignContentCampaignAsset( $post_id, $campaign_asset_guid );
 }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "roave/security-advisories": "dev-master",
         "squizlabs/php_codesniffer": "3.6.0",
         "wp-coding-standards/wpcs": "2.3.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "phpcompatibility/php-compatibility": "*"
     },
     "scripts": {
         "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffe1224cff2197db4d8a4cc2ff2b48d5",
+    "content-hash": "e685de14960554f6ee0778785b166ff8",
     "packages": [
         {
             "name": "carica/phpcss",
@@ -1568,6 +1568,68 @@
                 "source": "https://github.com/phar-io/version/tree/3.1.1"
             },
             "time": "2022-02-07T21:56:48+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3935,5 +3997,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,8 @@
 <ruleset name="Solutions Wordpress">
     <description>Solutions Wordpress Coding Standards</description>
 
+    <config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
+
     <file>./organic.php</file>
     <file>./Organic</file>
 
@@ -44,6 +46,8 @@
         <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
         <exclude name="WordPress.Security.EscapeOutput.UnsafePrintingFunction"/>
     </rule>
+
+    <rule ref="PHPCompatibility" />
 
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,8 +2,6 @@
 <ruleset name="Solutions Wordpress">
     <description>Solutions Wordpress Coding Standards</description>
 
-    <config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
-
     <file>./organic.php</file>
     <file>./Organic</file>
 
@@ -57,5 +55,6 @@
     </rule>
     <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
 
-    <config name="minimum_supported_wp_version" value="5.5"/>
+    <config name="minimum_supported_wp_version" value="5.0" />
+    <config name="testVersion" value="7.0" />
 </ruleset>


### PR DESCRIPTION
Some users reported issues with PHP 7.2, so reducing requirements to PHP 7.0 to expand compatibility with user Wordpress installations.