### PR TITLE
EP-2126: fill in keywords and section by categories slugs

### DIFF
--- a/Organic/AmpAdsInjector.php
+++ b/Organic/AmpAdsInjector.php
@@ -103,10 +103,11 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
             $targeting['targeting_keyword'] = $keywords;
         }
 
-        $category = $values['category'];
-        if ( ! is_null( $category ) ) {
-            $targeting['site_section'] = $category->slug;
-            $targeting['targeting_section'] = $category->slug;
+        $sections = $values['sections'];
+
+        if ( ! empty( $sections ) ) {
+            $targeting['site_section'] = $sections;
+            $targeting['targeting_section'] = $sections;
         }
 
         $json = json_encode( [ 'targeting' => $targeting ] );

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -484,54 +484,94 @@ class Organic {
 
     public function getSlugs( ...$terms ) {
         return array_map(
-            fn( $term ) => $term->slug,
+            function( $term ) {
+                return $term->slug;
+            },
             array_filter(
                 $terms,
-                fn( $term ) => is_a( $term, 'WP_Term' )
+                function( $term ) {
+                    return is_a( $term, 'WP_Term' );
+                }
             )
         );
+    }
+
+    /**
+     * Returns term's nesting level
+     *
+     * @param mixed $term
+     * @param int $maxLevel
+     * @return int
+     */
+    public function getTermLevel( $term, $maxLevel = 5 ) {
+        $level = 1;
+        $parent = $term;
+        for ( ;; ) {
+            if ( $parent->parent == 0 || $level >= $maxLevel ) {
+                break;
+            }
+            $parent = get_term_by( 'term_id', $parent->parent, $term->taxonomy );
+            $level++;
+        }
+        return $level;
     }
 
     public function getTargeting() {
         $post = get_post();
 
         $url = $this->getCurrentUrl();
-        $tags = $this->getTagsFor( $post->ID );
+        $keywords = $this->getTagsFor( $post->ID );
         $category = $this->getCategoryForCurrentPage();
-        $restCategories = [];
+        $sections = null;
 
         $id = '';
         $gamId = '';
         if ( is_single() ) {
             $id = esc_html( get_the_ID() );
             $gamId = get_post_meta( $id, GAM_ID_META_KEY, true );
-            $restCategories = $category
-                ? array_filter(
-                    get_the_terms( $post->ID, 'category' ),
-                    fn ( $term ) => $term->term_id != $category->term_id
-                )
-                : [];
+
+            $categories = get_the_terms( $post->ID, 'category' ) ?: [];
+            usort(
+                $categories,
+                function ( $a, $b ) {
+                    return $a->term_id - $b->term_id;
+                }
+            );
+
+            $c1terms = array_filter(
+                $categories,
+                function( $term ) {
+                    return $this->getTermLevel( $term ) == 1;
+                }
+            );
+
+            $c2terms = array_filter(
+                $categories,
+                function( $term ) {
+                    return $this->getTermLevel( $term ) > 1;
+                }
+            );
+
+            // $category can be set by WPSEO_Primary_Term
+            $sections = array_unique( $this->getSlugs( $category, ...$c1terms ) );
+            $keywords = array_merge(
+                $this->getSlugs( ...$c2terms ),
+                $keywords
+            );
         } else if ( is_category() ) {
             $id = 'channel-' . $category->slug;
+            $sections = [ $category->slug ];
         } else if ( is_page() ) {
             $id = 'page-' . $post->post_name;
         }
         $gamPageId = $gamId ? $gamId : $id;
         $gamExternalId = $id;
 
-        $firstOfRestCategories = array_shift( $restCategories );
-        $sections = $this->getSlugs( $category, $firstOfRestCategories );
-        $keywords = array_merge(
-            $this->getSlugs( ...$restCategories ),
-            $tags
-        );
-
         return [
             'siteDomain' => $this->siteDomain,
             'url' => $url,
             'sections' => $sections,
             'keywords' => $keywords,
-            'tags' => $tags,
             'category' => $category,
             'gamPageId' => $gamPageId,
             'gamExternalId' => $gamExternalId,

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -457,18 +457,13 @@ class Organic {
         return $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
     }
 
-    public function getKeywordsFor( $postId ) {
+    public function getTagsFor( $postId ) {
         $keywords = get_the_tags( $postId );
 
-        if ( $keywords && is_array( $keywords ) ) {
-            return array_map(
-                function( $tag ) {
-                    return $tag->slug;
-                },
-                $keywords
-            );
+        if ( ! is_array( $keywords ) ) {
+            return [];
         }
-        return [];
+        return $this->getSlugs( ...$keywords );
     }
 
     public function getCategoryForCurrentPage() {
@@ -487,18 +482,35 @@ class Organic {
         }
     }
 
+    public function getSlugs( ...$terms ) {
+        return array_map(
+            fn( $term ) => $term->slug,
+            array_filter(
+                $terms,
+                fn( $term ) => is_a( $term, 'WP_Term' )
+            )
+        );
+    }
+
     public function getTargeting() {
         $post = get_post();
 
         $url = $this->getCurrentUrl();
-        $keywords = $this->getKeywordsFor( $post->ID );
+        $tags = $this->getTagsFor( $post->ID );
         $category = $this->getCategoryForCurrentPage();
+        $restCategories = [];
 
         $id = '';
         $gamId = '';
         if ( is_single() ) {
             $id = esc_html( get_the_ID() );
             $gamId = get_post_meta( $id, GAM_ID_META_KEY, true );
+            $restCategories = $category
+                ? array_filter(
+                    get_the_terms( $post->ID, 'category' ),
+                    fn ( $term ) => $term->term_id != $category->term_id
+                )
+                : [];
         } else if ( is_category() ) {
             $id = 'channel-' . $category->slug;
         } else if ( is_page() ) {
@@ -507,10 +519,19 @@ class Organic {
         $gamPageId = $gamId ? $gamId : $id;
         $gamExternalId = $id;
 
+        $firstOfRestCategories = array_shift( $restCategories );
+        $sections = $this->getSlugs( $category, $firstOfRestCategories );
+        $keywords = array_merge(
+            $this->getSlugs( ...$restCategories ),
+            $tags
+        );
+
         return [
             'siteDomain' => $this->siteDomain,
             'url' => $url,
+            'sections' => $sections,
             'keywords' => $keywords,
+            'tags' => $tags,
             'category' => $category,
             'gamPageId' => $gamPageId,
             'gamExternalId' => $gamExternalId,

--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -232,16 +232,16 @@ class PageInjection {
         }
 
         if ( $this->organic->getPixelPublishedUrl() || $this->organic->getSiteId() ) {
-            $categoryString = '';
+            $sectionString = '';
             $keywordString = '';
             $targeting = $this->organic->getTargeting();
             $keywords = $targeting['keywords'];
-            $category = $targeting['category'];
+            $sections = $targeting['sections'];
             $gamPageId = $targeting['gamPageId'];
             $gamExternalId = $targeting['gamExternalId'];
 
-            if ( ! is_null( $category ) ) {
-                $categoryString = $category->slug;
+            if ( ! empty( $sections ) ) {
+                $sectionString = esc_html( implode( ',', $sections ) );
             }
 
             if ( ! empty( $keywords ) ) {
@@ -277,7 +277,7 @@ class PageInjection {
                     window.__trackadm_usp_cookie = 'ne-opt-out';
                     window.tadmPageId = '<?php echo $gamPageId; ?>';
                     window.tadmKeywords = '<?php echo $keywordString; ?>';
-                    window.tadmSection = '<?php echo $categoryString; ?>';
+                    window.tadmSection = '<?php echo $sectionString; ?>';
                     window.trackADMData = {
                         tests: BVTests.getTargetingValue()
                     };
@@ -299,7 +299,7 @@ class PageInjection {
                         externalId: '<?php echo $gamExternalId; ?>',
                         keywords: '<?php echo $keywordString; ?>',
                         disableKeywordReporting: false,
-                        section: '<?php echo $categoryString; ?>',
+                        section: '<?php echo $sectionString; ?>',
                         disableSectionReporting: false,
                         tests: BVTests.getTargetingValue(),
                     }


### PR DESCRIPTION
If the post belongs to several categories, section will be array of ~[primary_category, next_category]~ [...c1_slugs], and keywords will be merged array of ~[...rest_categories, ...tags]~ [...c2_slugs, ...c3_slugs, ..., ...tags]

<img width="1068" alt="Screenshot 2022-06-09 at 11 54 02" src="https://user-images.githubusercontent.com/10140290/172783773-35fec555-1df2-4b41-8f69-4ad94efd0999.png">

