### PR TITLE
EP-2178: Add option for foreground post syncs

### DIFF
--- a/Organic/AdminSettings.php
+++ b/Organic/AdminSettings.php
@@ -58,6 +58,7 @@ class AdminSettings {
                 $this->organic->updateOption( 'organic::inject_ads_config', isset( $_POST['organic_inject_ads_config'] ) ? true : false, false );
                 $this->organic->updateOption( 'organic::ad_slots_prefill_enabled', isset( $_POST['organic_ad_slots_prefill_enabled'] ) ? true : false, false );
                 $this->organic->updateOption( 'organic::campaigns_enabled', isset( $_POST['organic_campaigns_enabled'] ) ? true : false, false );
+                $this->organic->updateOption( 'organic::content_foreground', isset( $_POST['organic_content_foreground'] ) ? true : false, false );
                 $this->organic->sdk->updateToken( $_POST['organic_sdk_key'] );
                 $this->update_results[] = 'updated';
             }
@@ -130,6 +131,7 @@ class AdminSettings {
         $inject_ads_config = $this->organic->getOption( 'organic::inject_ads_config' );
         $ad_slots_prefill_enabled = $this->organic->getOption( 'organic::ad_slots_prefill_enabled' );
         $campaigns_enabled = $this->organic->getOption( 'organic::campaigns_enabled' );
+        $content_foreground = $this->organic->getOption( 'organic::content_foreground' );
 
         $total_published_posts = $this->organic->buildQuerySyncablePosts( 1 )->found_posts;
         $total_synced_posts = $this->organic->buildQueryNewlyUnsyncedPosts( 1 )->found_posts;
@@ -247,6 +249,15 @@ class AdminSettings {
                         Campaigns Application is enabled on the Platform
                     </label>
                 </p>
+                <label>
+                    <input
+                            type="checkbox"
+                            name="organic_content_foreground"
+                            id="organic_content_foreground"
+                        <?php echo $content_foreground ? 'checked' : ''; ?>
+                    />
+                    Force content updates to happen immediately on save. Only use if CRON is disabled on your site.
+                </label>
                 <p>
                     <input id="update-submit" type="submit" name="organic_update" value="Update" />
                     &nbsp;
@@ -346,5 +357,9 @@ class AdminSettings {
         }
 
         update_post_meta( $post_ID, SYNC_META_KEY, 'unsynced' );
+
+        if ( $this->organic->getContentForeground() ) {
+            $this->organic->syncPost( $post );
+        }
     }
 }

--- a/Organic/Organic.php
+++ b/Organic/Organic.php
@@ -43,6 +43,11 @@ class Organic {
     private $connatixPlayspaceId;
 
     /**
+     * @var bool True if we are forcing Content Meta synchronization into foreground
+     */
+    private $contentForeground = false;
+
+    /**
      * @var int % of traffic to send to Organic SDK instead of Organic Pixel
      */
     private $organicPixelTestPercent = 0;
@@ -255,6 +260,7 @@ class Organic {
         $this->postTypes = $this->getOption( 'organic::post_types', [ 'post', 'page' ] );
 
         $this->campaignsEnabled = $this->getOption( 'organic::campaigns_enabled' );
+        $this->contentForeground = $this->getOption( 'organic::content_foreground' );
 
         /* Load up our sub-page configs */
         new AdminSettings( $this );
@@ -1197,6 +1203,17 @@ class Organic {
 
     public function getAdsTxtManager() : AdsTxt {
         return $this->adsTxt;
+    }
+
+    /**
+     * Check if we are configured for foreground synchronization.
+     * This does not block background / cron based synchronization as well, but may make your saves slower for
+     * the editors.
+     *
+     * @return bool
+     */
+    public function getContentForeground() : bool {
+        return $this->contentForeground;
     }
 
     /**


### PR DESCRIPTION
Some users do not have any CRON mechanism set up on their Wordpress instance, and as a result we need to be able to synchronize Content Meta data when they save and not defer it until later.