### PR TITLE
EP-3358: Removing redundant ad setup call, fixing if statement condition

### DIFF
--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -415,8 +415,7 @@ class PageInjection {
                 <?php
                 if (
                         $this->organic->getOrganicPixelTestValue() &&
-                        $this->organic->getOrganicPixelTestPercent() != '' &&
-                        $this->organic->getOrganicPixelTestPercent() != null
+                        $this->organic->getOrganicPixelTestPercent() !== null
                 ) {
                     ?>
                 window.organicTestKey = "<?php echo $this->organic->getOrganicPixelTestValue(); ?>";
@@ -426,16 +425,8 @@ class PageInjection {
                 <?php } ?></script>
             <?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
             <script>
-                /* The below condition is a very specific case setup for Ads AB testing */
-                if (
-                    window.organicTestKey &&
-                    window.organicTestKey.indexOf('organic_adthrive') > -1 &&
-                    BVTests.getValue(window.organicTestKey) === 'control'
-                ) {
-                    if ( window.loadAdThrive && typeof window.loadAdThrive === 'function' )
-                        window.loadAdThrive(window, document);
-                }
-                else if ( window.organicTestKey && BVTests.getValue(window.organicTestKey) === 'control' ) {
+                if ( window.organicTestKey && BVTests.getValue(window.organicTestKey) === 'control' ) {
+                    // The below condition is a very specific case setup for Ads AB testing
                     // Do nothing here, but rely on third party code to detect the use case and load the ads their way
                 }
                 else {


### PR DESCRIPTION
**Change Request:**
We need to control how much traffic Organic Ads are loaded on for initial client onboarding. One instance is when the client are still working with other Ad Stack and we want to load our ads.txt entries without rendering any ads.
 
1. Organic Ad traffic control with 0% traffic was breaking as the condition 
`$this->organic->getOrganicPixelTestPercent() != ''` was comparing empty string to integer. This would always result in false and not create `BVTests` object.
<img width="381" alt="Screen Shot 2022-09-24 at 1 29 07 AM" src="https://user-images.githubusercontent.com/11287908/192047946-8c0103ac-f9e5-4297-976b-5b77213b750a.png">

2. Removed redundant AB testing code which instantiated other AdStack.