### PR TITLE
Fix strpos() Offset warning when the content is less than 200 symbols

### DIFF
--- a/Organic/PageInjection.php
+++ b/Organic/PageInjection.php
@@ -189,6 +189,9 @@ class PageInjection {
         $injectionPoint = strpos( $content, '</p>' );
         $injectionPointOffset = 4;
         if ( $injectionPoint === false || $injectionPoint > 1000 ) {
+            if ( strlen( $content ) <= 200 ) {
+                return $content;
+            }
             $spanInjectionPoint = strpos( $content, '</span>', 200 );
             if ( $spanInjectionPoint === false ) {
                 return $content;


### PR DESCRIPTION
![lcl fieldandstream com strpos](https://user-images.githubusercontent.com/104262358/203762395-e9778f81-592b-484f-ab74-075ce652349d.png)
