### PR TITLE
EP-4511 Modify Product Carousel height

### DIFF
--- a/affiliate/blocks/productCarousel/src/style.scss
+++ b/affiliate/blocks/productCarousel/src/style.scss
@@ -10,6 +10,6 @@
 }
 
 [data-organic-affiliate-integration="product-carousel"] {
-  min-height: 580px;
+  min-height: 640px;
   font-size: 0;
 }


### PR DESCRIPTION
This isn't a pressing change, as we are still making changes to the height in [this pr](https://github.com/orgnc/platform/pull/2888). Also, this isn't a _breaking_ change, since we have a `min-height` here. So, theoretically, the block should conform to the height of the iframe set by the SDK.