### PR TITLE
EP-4447: Refactor affiliate product card to use iframed product card creation widget

### DIFF
--- a/Organic/Affiliate.php
+++ b/Organic/Affiliate.php
@@ -31,12 +31,14 @@ class Affiliate {
             $this->organic->version
         );
         $product_search_page_url = $this->organic->getPlatformUrl() . '/apps/affiliate/integrations/product-search';
+        $product_card_creation_url = $this->organic->getPlatformUrl() . '/apps/affiliate/integrations/product-card';
         $product_carousel_creation_url = $this->organic->getPlatformUrl() . '/apps/affiliate/integrations/product-carousel';
         wp_localize_script(
             'organic-affiliate-product-card',
             'organic_affiliate_config_product_card',
             [
                 'productSearchPageUrl' => $product_search_page_url . '?siteGuid=' . $siteId,
+                'productCardCreationURL' => $product_card_creation_url . '?siteGuid=' . $siteId,
             ]
         );
         wp_localize_script(

--- a/affiliate/blocks/productCard/src/Edit.jsx
+++ b/affiliate/blocks/productCard/src/Edit.jsx
@@ -1,48 +1,26 @@
-import {
-  useBlockProps,
-  BlockControls,
-} from '@wordpress/block-editor';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import {
   Card,
   CardBody,
-  CardDivider,
-  CheckboxControl,
+  CardHeader,
   IconButton,
   Toolbar,
-  TextControl,
 } from '@wordpress/components';
 import {
   createRef,
   useCallback,
-  useEffect,
-  useMemo,
   useState,
 } from '@wordpress/element';
-import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 
 import ProductCard from './ProductCard';
-import ProductSearchModal from './ProductSearchModal';
+import ProductCardModal from './ProductCardModal';
 import { AttributesType } from './propTypes';
 
-const Edit = ({ attributes, setAttributes, productSearchPageUrl }) => {
+const Edit = ({ attributes, setAttributes, productCardCreationURL }) => {
   const productCardRef = createRef();
-  useEffect(() => {
-    if (attributes.productGuid) {
-      if (productCardRef.current) {
-        productCardRef.current.removeAttribute('data-organic-affiliate-processed');
-      }
-      window.empire?.apps?.affiliate?.init?.();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    attributes.productGuid,
-    attributes.displayImage,
-    attributes.displayDescription,
-    attributes.bannerText,
-    attributes.description, // description override
-  ]);
-  const [showModal, setShowModal] = useState(!attributes.productGuid);
+
+  const [showModal, setShowModal] = useState(!attributes.productCardSnippet);
   const hideModal = useCallback(
     () => setShowModal(false),
     [setShowModal],
@@ -52,122 +30,55 @@ const Edit = ({ attributes, setAttributes, productSearchPageUrl }) => {
     [setShowModal],
   );
 
-  const onProductSelect = useCallback(
-    ({ product }) => {
-      setAttributes({ productGuid: product.guid });
+  // format of arguments is based on data received from postMessage event in orgnc/platform file IntegrationProductCard.tsx
+  const onProductCardSelect = useCallback(
+    ({
+      productCardSnippet,
+      productCardEditURL,
+    }) => {
+      setAttributes({ productCardSnippet, productCardEditURL });
       hideModal();
+      if (productCardRef.current) {
+        productCardRef.current.removeAttribute('data-organic-affiliate-processed');
+      }
+      window.empire?.apps?.affiliate?.init?.();
     },
-    [setAttributes, hideModal],
-  );
-
-  const setDisplayImage = useCallback(
-    (displayImage) => setAttributes({ displayImage }),
-    [setAttributes],
-  );
-  const setDisplayDescription = useCallback(
-    (displayDescription) => setAttributes({ displayDescription }),
-    [setAttributes],
-  );
-
-  const debouncedSetBannerText = useMemo(
-    () => debounce((bannerText) => setAttributes({ bannerText }), 400),
-    [setAttributes],
-  );
-
-  const debouncedSetDescriptionText = useMemo(
-    () => debounce((description) => setAttributes({ description }), 400),
-    [setAttributes],
-  );
-
-  const [bannerTextValue, setBannerTextValue] = useState(attributes.bannerText);
-  const setBannerText = useCallback(
-    (bannerText) => {
-      setBannerTextValue(bannerText);
-      debouncedSetBannerText(bannerText);
-    },
-    [debouncedSetBannerText],
-  );
-
-  const [descriptionValue, setDescriptionValue] = useState(attributes.description);
-  const setDescriptionText = useCallback(
-    (description) => {
-      setDescriptionValue(description);
-      debouncedSetDescriptionText(description);
-    },
-    [debouncedSetDescriptionText],
+    [hideModal, productCardRef, setAttributes],
   );
 
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
+  // eslint-disable-next-line react/jsx-props-no-spreading
     <div {...useBlockProps()}>
-      {showModal
-        && (
-        <ProductSearchModal
+      {showModal && (
+        <ProductCardModal
           onClose={hideModal}
-          onProductSelect={onProductSelect}
-          productSearchPageUrl={productSearchPageUrl}
+          onProductCardSelect={onProductCardSelect}
+          productCardCreationURL={attributes.productCardEditURL || productCardCreationURL}
         />
-        )}
+      )}
       <BlockControls>
         <Toolbar>
           <IconButton
-            icon="search"
-            label="Select a product"
+            icon="edit"
+            label="Edit product card"
             onClick={displayModal}
           />
         </Toolbar>
       </BlockControls>
       <Card>
-        {attributes.productGuid ? (
-          <>
-            <CardBody>
-              <h4>Options</h4>
-              <CheckboxControl
-                checked={attributes.displayImage}
-                help="Whether or not the product image should be displayed"
-                label="Display Image"
-                onChange={setDisplayImage}
-              />
-              <CheckboxControl
-                checked={attributes.displayDescription}
-                help="Whether or not the product description should be displayed"
-                label="Display Description"
-                onChange={setDisplayDescription}
-              />
-              {attributes.displayImage && (
-                <TextControl
-                  help="Text for product card banner/award"
-                  label="Banner Text"
-                  onChange={setBannerText}
-                  value={bannerTextValue}
-                />
-              )}
-              {attributes.displayDescription && (
-                <TextControl
-                  help="Text to display instead of the default descriptoion"
-                  label="Description Text"
-                  onChange={setDescriptionText}
-                  value={descriptionValue}
-                />
-              )}
-            </CardBody>
-            <CardDivider />
-            <CardBody>
-              <ProductCard
-                ref={productCardRef}
-                bannerText={attributes.bannerText}
-                description={attributes.description}
-                displayDescription={attributes.displayDescription}
-                displayImage={attributes.displayImage}
-                productGuid={attributes.productGuid}
-              />
-            </CardBody>
-          </>
-        ) : (
-          <CardBody>
-            <h3>Product is not selected</h3>
-          </CardBody>
-        )}
+        <CardHeader>
+          Product Card
+        </CardHeader>
+        <CardBody>
+          {attributes.productCardSnippet ? (
+            <ProductCard
+              ref={productCardRef}
+              productCardSnippet={attributes.productCardSnippet}
+            />
+          ) : (
+            <h3>Product Card is unfinished.</h3>
+          )}
+        </CardBody>
       </Card>
     </div>
   );
@@ -176,7 +87,7 @@ const Edit = ({ attributes, setAttributes, productSearchPageUrl }) => {
 Edit.propTypes = {
   attributes: AttributesType.isRequired,
   setAttributes: PropTypes.func.isRequired,
-  productSearchPageUrl: PropTypes.string.isRequired,
+  productCardCreationURL: PropTypes.string.isRequired,
 };
 
 export default Edit;

--- a/affiliate/blocks/productCard/src/ProductCard.jsx
+++ b/affiliate/blocks/productCard/src/ProductCard.jsx
@@ -1,57 +1,19 @@
 import { forwardRef } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
-function serializeOptions(
-  displayDescription,
-  displayImage,
-  description,
-) {
-  const filteredOptions = { displayDescription, displayImage };
-  if (displayDescription) {
-    filteredOptions.description = description;
-  }
-  return Object.entries(filteredOptions)
-    .filter(([, value]) => (value !== '' && value != null))
-    .map(([key, value]) => `${key}=${value}`).join(',');
-}
-
 const ProductCard = forwardRef(({
-  productGuid,
-  displayImage,
-  displayDescription,
-  bannerText,
-  description,
+  productCardSnippet,
 }, ref) => {
-  if (!productGuid) {
-    return null;
-  }
-  const options = serializeOptions(displayDescription, displayImage, description);
-
   return (
     <div
+      dangerouslySetInnerHTML={{ __html: productCardSnippet }} // eslint-disable-line react/no-danger
       ref={ref}
-      data-organic-affiliate-integration="product-card"
-      data-organic-affiliate-integration-banner-text={bannerText}
-      data-organic-affiliate-integration-options={options}
-      data-organic-affiliate-product-guid={productGuid}
     />
   );
 });
 
 ProductCard.propTypes = {
-  productGuid: PropTypes.string,
-  displayImage: PropTypes.bool,
-  displayDescription: PropTypes.bool,
-  bannerText: PropTypes.string,
-  description: PropTypes.string,
-};
-
-ProductCard.defaultProps = {
-  productGuid: '',
-  displayImage: true,
-  displayDescription: false,
-  bannerText: '',
-  description: '',
+  productCardSnippet: PropTypes.string.isRequired,
 };
 
 export default ProductCard;

--- a/affiliate/blocks/productCard/src/ProductCardModal.jsx
+++ b/affiliate/blocks/productCard/src/ProductCardModal.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+
+import IntegrationModal from '../../shared/IntegrationModal';
+
+const ProductCarouselModal = ({
+  onClose,
+  onProductCardSelect,
+  productCardCreationURL,
+}) => (
+  <IntegrationModal
+    iframeURL={productCardCreationURL}
+    integrationMessageType="organic/affiliate-select-product-card"
+    onClose={onClose}
+    onIntegrationSelect={onProductCardSelect}
+    title="Product Card Creation"
+  />
+);
+
+ProductCarouselModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onProductCardSelect: PropTypes.func.isRequired,
+  productCardCreationURL: PropTypes.string.isRequired,
+};
+
+export default ProductCarouselModal;

--- a/affiliate/blocks/productCard/src/Save.jsx
+++ b/affiliate/blocks/productCard/src/Save.jsx
@@ -1,25 +1,19 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
-import ProductCard from './ProductCard';
+import ProductCarousel from './ProductCard';
 import { AttributesType } from './propTypes';
 
-const Save = ({ attributes }) => {
-  return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <div {...useBlockProps.save()}>
-      {attributes?.productGuid
-        && (
-        <ProductCard
-          bannerText={attributes.bannerText}
-          description={attributes.description}
-          displayDescription={attributes.displayDescription}
-          displayImage={attributes.displayImage}
-          productGuid={attributes.productGuid}
-        />
-        )}
-    </div>
-  );
-};
+const Save = ({ attributes }) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <div {...useBlockProps.save()}>
+    {attributes?.productCarouselSnippet && (
+      <ProductCarousel
+        productCardEditURL={attributes.productCardEditURL}
+        productCardSnippet={attributes.productCardSnippet}
+      />
+    )}
+  </div>
+);
 
 Save.propTypes = {
   attributes: AttributesType.isRequired,

--- a/affiliate/blocks/productCard/src/index.js
+++ b/affiliate/blocks/productCard/src/index.js
@@ -12,43 +12,18 @@ register(organic_affiliate_config_product_card.productSearchPageUrl);
 
 registerBlockType('organic/affiliate-product-card', {
   attributes: {
-    productGuid: {
+    productCardEditURL: {
       type: 'string',
-      source: 'attribute',
-      selector: '[data-organic-affiliate-integration="product-card"]',
-      attribute: 'data-organic-affiliate-product-guid',
     },
-    displayImage: {
-      type: 'boolean',
-      default: true,
-    },
-    displayDescription: {
-      type: 'boolean',
-      default: false,
-    },
-    bannerText: {
+    productCardSnippet: {
       type: 'string',
-      default: '',
-    },
-    description: {
-      type: 'string',
-      default: '',
-    },
-  },
-  example: {
-    attributes: {
-      productGuid: '964805c4-6bf7-4418-a112-a58f1565a72d',
-      displayImage: true,
-      displayDescription: false,
-      bannerText: 'Best Value',
-      description: 'Made from 100% recycled materials',
     },
   },
   icon: OrganicIcon,
   edit: (props) => (
     <Edit
       {...props}
-      productSearchPageUrl={organic_affiliate_config_product_card.productSearchPageUrl}
+      productCardCreationURL={organic_affiliate_config_product_card.productCardCreationURL}
     />
   ),
   save: Save,

--- a/affiliate/blocks/productCard/src/propTypes.js
+++ b/affiliate/blocks/productCard/src/propTypes.js
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 
 export const AttributesType = PropTypes.shape({
-  bannerText: PropTypes.string.isRequired,
-  displayImage: PropTypes.bool.isRequired,
-  displayDescription: PropTypes.bool.isRequired,
-  productGuid: PropTypes.string.isRequired,
-  description: PropTypes.string,
+  productCardEditURL: PropTypes.string,
+  productCardSnippet: PropTypes.bool.isRequired,
 });

--- a/affiliate/blocks/productCarousel/src/Edit.jsx
+++ b/affiliate/blocks/productCarousel/src/Edit.jsx
@@ -59,8 +59,8 @@ const Edit = ({ attributes, setAttributes, productCarouselCreationURL }) => {
       <BlockControls>
         <Toolbar>
           <IconButton
-            icon="search"
-            label="Select a product"
+            icon="edit"
+            label="Edit carousel"
             onClick={displayModal}
           />
         </Toolbar>


### PR DESCRIPTION
This PR modifies the product card so that it is built using the platform widget's component rather than using separate, WordPress-specific form controls. This ensures that any changes we make to product card creation can be executed in one spot rather than having to make the changes both in the platform code (widgets page) and in the wordpress-plugin code. The PR also changes the edit icon for both the product card and the product carousel from a magnifying glass to a pencil.

Note that as soon as this PR is in production (when this PR is released and the solutions-wordpress code is updated to use the latest wordpress-plugin version), creating new product cards will be temporarily broken until https://github.com/orgnc/organic-web/pull/1486 is released. Once this organic-web PR is released, existing product cards will be temporarily broken, but product creation will work. See the organic-web PR for details.

Before:

https://user-images.githubusercontent.com/47676832/210881223-616b8ed4-170d-46f3-b04f-56e73d7da204.mov


After:


https://user-images.githubusercontent.com/47676832/210880714-b5967eb5-255f-4392-8893-da2801aeb513.mov

