### PR TITLE
Modify build-zip.sh to include new affiliate SDK script

### DIFF
--- a/build-zip.sh
+++ b/build-zip.sh
@@ -33,6 +33,7 @@ cp -r affiliate/blocks/productCard/build build/organic/affiliate/blocks/productC
 cp affiliate/blocks/productCard/block.json build/organic/affiliate/blocks/productCard/
 cp -r affiliate/blocks/productCarousel/build build/organic/affiliate/blocks/productCarousel/
 cp affiliate/blocks/productCarousel/block.json build/organic/affiliate/blocks/productCarousel/
+cp affiliate/initSDKOnPostLoad.js build/organic/affiliate/
 cd build
 zip -r organic-${BUILD_NUMBER}.zip organic
 cp organic-${BUILD_NUMBER}.zip organic.zip


### PR DESCRIPTION
In https://github.com/orgnc/wordpress-plugin/pull/142, I added a new affiliate script that would run our SDK so that widgets displayed correctly. I tested locally, but testing on a feature PR [here](https://github.com/orgnc/solutions-wordpress/pull/3837), I realized that build-zip.sh hadn't been updated to copy the file containing the script (which, no surprises, leads to a 404 error in the console). This PR fixes the issue. I've tested locally once more, including a test with the plugin directory built via build-zip.sh to better mimic the feature/production environment.