### PR TITLE
Bugfix: Get affiliate SDK reinit script working on Firefox

### DIFF
--- a/affiliate/initSDKOnPostLoad.js
+++ b/affiliate/initSDKOnPostLoad.js
@@ -8,12 +8,12 @@ const handlePageLoad = () => {
     // Affiliate
     if (affiliate && affiliate?.isEnabled()) {
       if (!affiliate.isInitialized()) {
-        affiliate.init();
+        setTimeout(() => affiliate.init(), 0);
       } else {
-        affiliate.processPage();
+        setTimeout(() => affiliate.processPage(), 0);
       }
     }
   });
 };
 
-window.addEventListener('load', handlePageLoad);
+window.addEventListener('pageshow', handlePageLoad);


### PR DESCRIPTION
- Using `pageshow` event instead of `load` because `pageshow` is more robust (see https://developer.mozilla.org/en-US/docs/Web/API/Window/pageshow_event). I saw some threads about `load` difficulties with Firefox. (See, e.g., https://stackoverflow.com/questions/15945206/window-load-doesnt-seem-to-be-working-in-firefox.)
- Use setTimeout 0 to run the script after the JS runtime stack has been processed.