### PR TITLE
EP-5061: Add affiliate block script dependencies to wp_register_script

### DIFF
--- a/src/Organic/Affiliate.php
+++ b/src/Organic/Affiliate.php
@@ -25,16 +25,19 @@ class Affiliate {
             // Gutenberg blocks are not supported
             return;
         }
+        // As more blocks are added, create a function like "register_widget_block_script".
+        $card_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCard/build/index.asset.php' );
         wp_register_script(
             'organic-affiliate-product-card',
             plugins_url( 'blocks/affiliate/productCard/build/index.js', __DIR__ ),
-            [ 'organic-sdk' ],
+            $card_asset_file['dependencies'],
             $this->organic->version
         );
+        $carousel_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCarousel/build/index.asset.php' );
         wp_register_script(
             'organic-affiliate-product-carousel',
             plugins_url( 'blocks/affiliate/productCarousel/build/index.js', __DIR__ ),
-            [ 'organic-sdk' ],
+            $carousel_asset_file['dependencies'],
             $this->organic->version
         );
         if ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {

--- a/src/Organic/Affiliate.php
+++ b/src/Organic/Affiliate.php
@@ -27,17 +27,20 @@ class Affiliate {
         }
         // As more blocks are added, create a function like "register_widget_block_script".
         $card_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCard/build/index.asset.php' );
+        // wp-scripts 5.0.0+ generates an index.asset.php file with dependencies. If the wp-scripts version is before
+        // this, we specify known dependencies explicitly.
+        $legacy_block_dependencies = [ 'organic-sdk', 'wp-block-editor', 'wp-blocks', 'wp-polyfill' ];
         wp_register_script(
             'organic-affiliate-product-card',
             plugins_url( 'blocks/affiliate/productCard/build/index.js', __DIR__ ),
-            $card_asset_file['dependencies'],
+            $card_asset_file['dependencies'] ?? $legacy_block_dependencies,
             $this->organic->version
         );
         $carousel_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCarousel/build/index.asset.php' );
         wp_register_script(
             'organic-affiliate-product-carousel',
             plugins_url( 'blocks/affiliate/productCarousel/build/index.js', __DIR__ ),
-            $carousel_asset_file['dependencies'],
+            $carousel_asset_file['dependencies'] ?? $legacy_block_dependencies,
             $this->organic->version
         );
         if ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {

--- a/src/Organic/Affiliate.php
+++ b/src/Organic/Affiliate.php
@@ -27,20 +27,17 @@ class Affiliate {
         }
         // As more blocks are added, create a function like "register_widget_block_script".
         $card_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCard/build/index.asset.php' );
-        // wp-scripts 5.0.0+ generates an index.asset.php file with dependencies. If the wp-scripts version is before
-        // this, we specify known dependencies explicitly.
-        $legacy_block_dependencies = [ 'organic-sdk', 'wp-block-editor', 'wp-blocks', 'wp-polyfill' ];
         wp_register_script(
             'organic-affiliate-product-card',
             plugins_url( 'blocks/affiliate/productCard/build/index.js', __DIR__ ),
-            $card_asset_file['dependencies'] ?? $legacy_block_dependencies,
+            $card_asset_file['dependencies'],
             $this->organic->version
         );
         $carousel_asset_file = include( plugin_dir_path( __DIR__ ) . 'blocks/affiliate/productCarousel/build/index.asset.php' );
         wp_register_script(
             'organic-affiliate-product-carousel',
             plugins_url( 'blocks/affiliate/productCarousel/build/index.js', __DIR__ ),
-            $carousel_asset_file['dependencies'] ?? $legacy_block_dependencies,
+            $carousel_asset_file['dependencies'],
             $this->organic->version
         );
         if ( 'post.php' === $hook_suffix || 'post-new.php' === $hook_suffix ) {


### PR DESCRIPTION
I should have named this branch `bugfix/...` but I didn't think it was worth creating a new branch.

In any case, this PR fixes an error in which affiliate blocks were not working properly because their dependencies were not registered correctly. See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/javascript/js-build-setup.md#dependency-management.

Quick video showing them working again (ignore the awful styling--I was testing something else locally):

https://user-images.githubusercontent.com/47676832/230426534-446f91bf-003c-43f0-9ca2-0c949e323295.mov

