### PR TITLE
EP-5162: Add testInsertMagicLink

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,9 @@ WP61_PHP82_PORT=8034
 # TODO: FILL IT and uncomment!
 # Get API key from https://app.organic.ly/apps/organic-ads/documentation (switch to "Organic Demo" org/site)
 # ORGANIC_DEMO_SITE_APIKEY=''
+# To run selenium tests, you'll need the following credentials from 1Password:
+# ORGANIC_TEST_USER_EMAIL=''
+# ORGANIC_TEST_USER_PASSWORD=''
 
 # TODO: FILL IT and uncomment!
 # https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,6 +19,8 @@ jobs:
     env:
       PROJECT: wordpress-plugin
       ORGANIC_DEMO_SITE_APIKEY: ${{ secrets.ORGANIC_DEMO_SITE_API_KEY }}
+      ORGANIC_TEST_USER_EMAIL: ${{ secrets.ORGANIC_TEST_USER_EMAIL }}
+      ORGANIC_TEST_USER_PASSWORD: ${{ secrets.ORGANIC_TEST_USER_PASSWORD }}
       COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
     steps:
       - uses: actions/checkout@v3

--- a/dev.py
+++ b/dev.py
@@ -25,6 +25,12 @@ REQUIRED_ENVVARS = [
     'WP61_PHP82_PORT',
 ]
 
+# Environment variables that are only required for some features, but not all.
+RECOMMENDED_ENVVARS = [
+    'ORGANIC_TEST_USER_EMAIL',
+    'ORGANIC_TEST_USER_PASSWORD',
+]
+
 
 def info(msg, color='bright_magenta'):
     click.echo()
@@ -160,11 +166,13 @@ def configure_organic_plugin_sql(db_name, site_id, api_key):
      """
 
 
-def get_env_var(varname):
+def get_env_var(varname, required: bool = True):
     value = os.environ.get(varname, '')
-    if not value:
+    if not value and required:
         click.secho(f"The {varname} is not passed! Ensure it's defined in `.env` file ", fg='red')
         sys.exit(1)
+    if not value:
+        click.secho(f"Warning: {varname} is not passed. Certain functionality might not work properly ", fg='yellow')
 
     return value
 
@@ -217,6 +225,8 @@ def cli(ctx):
 
     for envvar in REQUIRED_ENVVARS:
         get_env_var(envvar)
+    for envvar in RECOMMENDED_ENVVARS:
+        get_env_var(envvar, required=False)
 
     ctx.obj = get_compose_config()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ x-templates:
     ORGANIC_ENVIRONMENT: ${ORGANIC_ENVIRONMENT}
     ORGANIC_API_URL: ${ORGANIC_API_URL}
     ORGANIC_CDN_URL: ${ORGANIC_CDN_URL}
+
     # This tells our reverse proxy which container services the wpplugin URL.
     # Every wp service has the same alias/virtual host setting, but they differ
     # in which ports they listen to.
@@ -137,6 +138,8 @@ services:
       COMPOSER_AUTH: ${COMPOSER_AUTH}
       WP_HOME: 'http://wpplugin.lcl.organic.ly'
       SELENIUM_URL: 'http://selenium:4444/wd/hub'
+      ORGANIC_TEST_USER_EMAIL: ${ORGANIC_TEST_USER_EMAIL}
+      ORGANIC_TEST_USER_PASSWORD: ${ORGANIC_TEST_USER_PASSWORD}
     volumes:
       - ./src:/app
 

--- a/src/tests/SeleniumBrowser.php
+++ b/src/tests/SeleniumBrowser.php
@@ -270,22 +270,13 @@ class SeleniumBrowser {
     }
 
     /**
-     * @param int $index
      * @return mixed
      * @throws Exception
+     * Find and return the Organic widgets iframe.
      */
-    function getIframe( int $index ) {
-        return $this->waitFor('iframe', null, null, true )[$index];
-    }
-
-    /**
-     * @param int $index
-     * @return mixed
-     * @throws Exception
-     */
-    function getIframeURL( int $index ) {
-        $iframe = $this->getIframe( $index );
-        return $iframe->getAttribute( 'src' );
+    function getOrganicIframe( ) {
+        // TODO: The blocks should return a dynamic URL depending on the environment.
+        return $this->waitFor( 'iframe[src^="https://app.organic.ly"]', null );
     }
 
     /**

--- a/src/tests/SeleniumBrowser.php
+++ b/src/tests/SeleniumBrowser.php
@@ -274,9 +274,55 @@ class SeleniumBrowser {
      * @return mixed
      * @throws Exception
      */
+    function getIframe( int $index ) {
+        return $this->waitFor('iframe', null, null, true )[$index];
+    }
+
+    /**
+     * @param int $index
+     * @return mixed
+     * @throws Exception
+     */
     function getIframeURL( int $index ) {
-        $iframe = $this->waitFor('iframe', null, null, true )[$index];
+        $iframe = $this->getIframe( $index );
         return $iframe->getAttribute( 'src' );
+    }
+
+    /**
+     * @param $elementOrSelector
+     */
+    function switchToIframe( $elementOrSelector ) {
+        $this->driver->switchTo()->frame( $elementOrSelector );
+        $this->waitForDocumentReady();
+    }
+
+    /**
+     * @return void
+     */
+    function switchToDefaultContext() {
+        $this->driver->switchTo()->defaultContent();
+    }
+
+    /**
+     * @param int $x
+     * @param int $y
+     * @return void
+     */
+    function moveCursor( int $x = 0, int $y = 0) {
+        $action = $this->driver->action();
+        $action->moveByOffset($x, $y)->Perform();
+    }
+
+    /**
+     * @param int $index
+     * @param string $text
+     * @return void
+     * @throws Exception
+     */
+    function fillParagraphBlock( int $index = 0, string $text = '' ) {
+        // WordPress does some annoying DOM manipulation, so we need to click the p element first.
+        $this->click( $this->getElementIfItExists( 'p', true )[$index] );
+        $this->fillTextInput( $this->getElementIfItExists( 'p', true )[$index], $text );
     }
 
 }

--- a/src/tests/test_affiliate/WidgetsTest.php
+++ b/src/tests/test_affiliate/WidgetsTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\TestCase;
 include( __DIR__ . '/../SeleniumBrowser.php' );
 
 define( "Organic\WP_VERSION", getenv( 'WP_VERSION' ) ?? '' );
+define( "Organic\ORGANIC_TEST_USER_EMAIL", getenv( 'ORGANIC_TEST_USER_EMAIL' ) ?? '' );
+define( "Organic\ORGANIC_TEST_USER_PASSWORD", getenv( 'ORGANIC_TEST_USER_PASSWORD' ) ?? '' );
+const TEST_PRODUCT_GUID = '7cbfc98e-ffcc-456e-ac5d-831150f43177';
 
 class WidgetsTest extends TestCase {
 
@@ -63,6 +66,52 @@ class WidgetsTest extends TestCase {
      */
     public function testProductCarouselAvailable() {
         $this->checkWidgetIsAvailable( 'organic-affiliate-product-carousel' );
+    }
+
+    /**
+     * Test that we can insert an Organic Affiliate magic link.
+     * @group selenium_test
+     */
+    public function testInsertMagicLink() {
+        if ( $this->wordPressVersionTooLow() ) {
+            $this->fail( 'WordPress version ' . WP_VERSION . ' does not support custom blocks.' );
+        }
+        if ( ! ORGANIC_TEST_USER_EMAIL || ! ORGANIC_TEST_USER_PASSWORD ) {
+            $this->fail(
+                'Cannot run testInsertMagicLink without ORGANIC_TEST_USER_EMAIL and ORGANIC_TEST_USER_PASSWORD set'
+            );
+        }
+        $browser = SeleniumBrowser::getTestBrowser();
+        try {
+            $browser->goToNewPost();
+            $browser->fillParagraphBlock( 0, 'testing...' );
+            // The toolbar only displays after mouse movement.
+            $browser->moveCursor( 0, 10 );
+            // The toolbar should be visible. We click the Organic Tools menu item.
+            $browser->click( '[aria-label="Organic Tools"]' );
+            // Then we click the submenu item.
+            $browser->click( 'button[role="menuitem"]' );
+            // The Organic iframe should appear.
+            $iframe = $browser->getIframe( 0 );
+            $browser->switchToIframe( $iframe );
+            # Log in with test account.
+            $browser->fillTextInput( '#email', ORGANIC_TEST_USER_EMAIL );
+            $browser->fillTextInput( '#password', ORGANIC_TEST_USER_PASSWORD );
+            $browser->click( '#signin-button' );
+            $browser->wait();
+            # Search for the test product.
+            $browser->fillTextInput( '#affiliate-product-search-entry', 'Selenium Test Product' );
+            $browser->click( '[data-test-element="affiliate-offer-button"]' );
+            # We move out of the iframe and check that the link has been added for the test product.
+            $browser->switchToDefaultContext();
+            $guid = TEST_PRODUCT_GUID;
+            $browser->waitFor( "[href$=\"{$guid}/\"]", null );
+            $browser->quit();
+            $this->assertTrue( true );
+        } catch ( Exception $e ) {
+            $browser->quit();
+            $this->fail( $e );
+        }
     }
 
 }

--- a/src/tests/test_affiliate/WidgetsTest.php
+++ b/src/tests/test_affiliate/WidgetsTest.php
@@ -104,6 +104,7 @@ class WidgetsTest extends TestCase {
             $browser->click( '[data-test-element="affiliate-offer-button"]' );
             # We move out of the iframe and check that the link has been added for the test product.
             $browser->switchToDefaultContext();
+            $browser->wait( .5 );
             $guid = TEST_PRODUCT_GUID;
             $browser->waitFor( "[href$=\"{$guid}/\"]", null );
             $browser->quit();

--- a/src/tests/test_affiliate/WidgetsTest.php
+++ b/src/tests/test_affiliate/WidgetsTest.php
@@ -34,18 +34,10 @@ class WidgetsTest extends TestCase {
         try {
             $browser->goToNewPost();
             $browser->addBlock( $blockType );
-
-            // Total hack. I cannot figure out why the iframe src attribute is empty in 5.9 (and presumably
-            // some other WP versions). The page content looks basically the same as for 6.1,
-            // which works fine, and I can visually see the correct URL in Selenium Grid's live view.
-            // Let's get rid of this when we figure out the issue.
-            if ( !empty( WP_VERSION ) && WP_VERSION == '5.9' ) {
-                $urlCorrect = true;
-            } else {
-                $urlCorrect = str_contains( $browser->getIframeURL( 0 ), 'app.organic.ly' );
-            }
+            // Check the Organic iframe appears.
+            $browser->getOrganicIframe();
             $browser->quit();
-            $this->assertTrue( $urlCorrect );
+            $this->assertTrue( true );
         } catch ( Exception $e ) {
             $browser->quit();
             $this->fail( $e->getMessage() );
@@ -92,19 +84,18 @@ class WidgetsTest extends TestCase {
             // Then we click the submenu item.
             $browser->click( 'button[role="menuitem"]' );
             // The Organic iframe should appear.
-            $iframe = $browser->getIframe( 0 );
+            $iframe = $browser->getOrganicIframe();
             $browser->switchToIframe( $iframe );
             # Log in with test account.
             $browser->fillTextInput( '#email', ORGANIC_TEST_USER_EMAIL );
             $browser->fillTextInput( '#password', ORGANIC_TEST_USER_PASSWORD );
             $browser->click( '#signin-button' );
-            $browser->wait();
             # Search for the test product.
             $browser->fillTextInput( '#affiliate-product-search-entry', 'Selenium Test Product' );
             $browser->click( '[data-test-element="affiliate-offer-button"]' );
             # We move out of the iframe and check that the link has been added for the test product.
             $browser->switchToDefaultContext();
-            $browser->wait( .5 );
+            $browser->wait();
             $guid = TEST_PRODUCT_GUID;
             $browser->waitFor( "[href$=\"{$guid}/\"]", null );
             $browser->quit();


### PR DESCRIPTION
I've added a Selenium test to check that the user can insert an Organic Affiliate "magic" link. Brief summary:

- I created a test user with credentials shared via 1Password (Organic->Shared->Organic Login External Selenium Tests), which have been added as secrets to this repo.
- I created a [test product](https://app.organic.ly/apps/affiliate/products/7cbfc98e-ffcc-456e-ac5d-831150f43177?siteGuid=1579aae8-85e4-4ca7-b556-7b52816f529c) (for Organic Demo).
- The test itself goes to a post, selects the icon to insert and Organic link, logs into the Organic Affiliate widgets page that appears as an iframe using the test credentials, searches for and selects the test product, and then checks that the link has been inserted.

In the process, I fixed an iframe selection issue for wp59.

If this PR is approved, I can extend the product card and carousel tests to log in and actual add the widgets.