### PR TITLE
EP-5546: Widget Insertion Refresh Part 2

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.4.2
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/src/Organic/PageInjection.php
+++ b/src/Organic/PageInjection.php
@@ -159,12 +159,13 @@ class PageInjection {
         <script id="organic-sdk-affiliate-admin-blocks-process">
             // Make sure we re-process the page after all blocks loaded
             window.addEventListener('pageshow', function() {
-                window.organic.cmd.push(function(apps) {
-                    var affiliate = apps.affiliate;
-                    if (!affiliate || !affiliate.isEnabled()) return;
-
-                    setTimeout(() => affiliate.processPage(), 0);
-                });
+                setTimeout(() => {
+                    window.organic.cmd.push(function(apps) {
+                        var affiliate = apps.affiliate;
+                        if (!affiliate || !affiliate.isEnabled()) return;
+                        affiliate.processPage();
+                    })
+                }, 0);
             });
         </script>
         <?php

--- a/src/Organic/PageInjection.php
+++ b/src/Organic/PageInjection.php
@@ -155,19 +155,6 @@ class PageInjection {
 
         $this->injectCoreSetup();
         $this->injectAffiliateSetup();
-        ?>
-        <script id="organic-sdk-affiliate-admin-blocks-process">
-            // Make sure we re-process the page after all blocks loaded
-            window.addEventListener('pageshow', function() {
-                window.organic.cmd.push(function(apps) {
-                    var affiliate = apps.affiliate;
-                    if (!affiliate || !affiliate.isEnabled()) return;
-
-                    setTimeout(() => affiliate.processPage(), 500);
-                });
-            });
-        </script>
-        <?php
         $this->injectScriptTag(
             'organic-sdk',
             $this->organic->getSdkUrl(),

--- a/src/Organic/PageInjection.php
+++ b/src/Organic/PageInjection.php
@@ -159,13 +159,12 @@ class PageInjection {
         <script id="organic-sdk-affiliate-admin-blocks-process">
             // Make sure we re-process the page after all blocks loaded
             window.addEventListener('pageshow', function() {
-                setTimeout(() => {
-                    window.organic.cmd.push(function(apps) {
-                        var affiliate = apps.affiliate;
-                        if (!affiliate || !affiliate.isEnabled()) return;
-                        affiliate.processPage();
-                    })
-                }, 0);
+                window.organic.cmd.push(function(apps) {
+                    var affiliate = apps.affiliate;
+                    if (!affiliate || !affiliate.isEnabled()) return;
+
+                    setTimeout(() => affiliate.processPage(), 500);
+                });
             });
         </script>
         <?php

--- a/src/blocks/affiliate/productCard/src/Edit.jsx
+++ b/src/blocks/affiliate/productCard/src/Edit.jsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
-import { refreshAffiliateWidgets } from '../../shared/helpers';
+import { refreshAffiliateWidgetsOnEdit } from '../../shared/helpers';
 import ProductCard from './ProductCard';
 import ProductCardModal from './ProductCardModal';
 import { AttributesType } from './propTypes';
@@ -42,7 +42,7 @@ const Edit = ({ attributes, setAttributes, productCardCreationURL }) => {
       if (productCardRef.current) {
         productCardRef.current.removeAttribute('data-organic-affiliate-processed');
       }
-      refreshAffiliateWidgets();
+      refreshAffiliateWidgetsOnEdit();
     },
     [hideModal, productCardRef, setAttributes],
   );

--- a/src/blocks/affiliate/productCard/src/Edit.jsx
+++ b/src/blocks/affiliate/productCard/src/Edit.jsx
@@ -3,8 +3,6 @@ import {
   Card,
   CardBody,
   CardHeader,
-  IconButton,
-  Toolbar,
 } from '@wordpress/components';
 import {
   createRef,
@@ -14,6 +12,7 @@ import {
 import PropTypes from 'prop-types';
 
 import { refreshAffiliateWidgetsOnEdit } from '../../shared/helpers';
+import WidgetToolbar from '../../shared/WidgetToolbar';
 import ProductCard from './ProductCard';
 import ProductCardModal from './ProductCardModal';
 import { AttributesType } from './propTypes';
@@ -58,13 +57,9 @@ const Edit = ({ attributes, setAttributes, productCardCreationURL }) => {
         />
       )}
       <BlockControls>
-        <Toolbar>
-          <IconButton
-            icon="edit"
-            label="Edit product card"
-            onClick={displayModal}
-          />
-        </Toolbar>
+        <BlockControls>
+          <WidgetToolbar onEdit={displayModal} />
+        </BlockControls>
       </BlockControls>
       <Card>
         <CardHeader>

--- a/src/blocks/affiliate/productCard/src/Save.jsx
+++ b/src/blocks/affiliate/productCard/src/Save.jsx
@@ -1,18 +1,22 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
+import { refreshAffiliateWidgetsOnSave } from '../../shared/helpers';
 import ProductCard from './ProductCard';
 import { AttributesType } from './propTypes';
 
-const Save = ({ attributes }) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <div {...useBlockProps.save()}>
-    {attributes?.productCardSnippet && (
-      <ProductCard
-        productCardSnippet={attributes.productCardSnippet}
-      />
-    )}
-  </div>
-);
+const Save = ({ attributes }) => {
+  refreshAffiliateWidgetsOnSave();
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <div {...useBlockProps.save()}>
+      {attributes?.productCardSnippet && (
+        <ProductCard
+          productCardSnippet={attributes.productCardSnippet}
+        />
+      )}
+    </div>
+  );
+};
 
 Save.propTypes = {
   attributes: AttributesType.isRequired,

--- a/src/blocks/affiliate/productCarousel/src/Edit.jsx
+++ b/src/blocks/affiliate/productCarousel/src/Edit.jsx
@@ -3,8 +3,6 @@ import {
   Card,
   CardBody,
   CardHeader,
-  IconButton,
-  Toolbar,
 } from '@wordpress/components';
 import {
   createRef,
@@ -14,6 +12,7 @@ import {
 import PropTypes from 'prop-types';
 
 import { refreshAffiliateWidgetsOnEdit } from '../../shared/helpers';
+import WidgetToolbar from '../../shared/WidgetToolbar';
 import ProductCarousel from './ProductCarousel';
 import ProductCarouselModal from './ProductCarouselModal';
 import { AttributesType } from './propTypes';
@@ -58,13 +57,7 @@ const Edit = ({ attributes, setAttributes, productCarouselCreationURL }) => {
         />
       )}
       <BlockControls>
-        <Toolbar>
-          <IconButton
-            icon="edit"
-            label="Edit carousel"
-            onClick={displayModal}
-          />
-        </Toolbar>
+        <WidgetToolbar onEdit={displayModal} />
       </BlockControls>
       <Card>
         <CardHeader>

--- a/src/blocks/affiliate/productCarousel/src/Edit.jsx
+++ b/src/blocks/affiliate/productCarousel/src/Edit.jsx
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
-import { refreshAffiliateWidgets } from '../../shared/helpers';
+import { refreshAffiliateWidgetsOnEdit } from '../../shared/helpers';
 import ProductCarousel from './ProductCarousel';
 import ProductCarouselModal from './ProductCarouselModal';
 import { AttributesType } from './propTypes';
@@ -42,7 +42,7 @@ const Edit = ({ attributes, setAttributes, productCarouselCreationURL }) => {
       if (productCarouselRef.current) {
         productCarouselRef.current.removeAttribute('data-organic-affiliate-processed');
       }
-      refreshAffiliateWidgets();
+      refreshAffiliateWidgetsOnEdit();
     },
     [hideModal, productCarouselRef, setAttributes],
   );

--- a/src/blocks/affiliate/productCarousel/src/Save.jsx
+++ b/src/blocks/affiliate/productCarousel/src/Save.jsx
@@ -1,19 +1,23 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
+import { refreshAffiliateWidgetsOnSave } from '../../shared/helpers';
 import ProductCarousel from './ProductCarousel';
 import { AttributesType } from './propTypes';
 
-const Save = ({ attributes }) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <div {...useBlockProps.save()}>
-    {attributes?.productCarouselSnippet && (
-      <ProductCarousel
-        productCarouselEditURL={attributes.productCarouselEditURL}
-        productCarouselSnippet={attributes.productCarouselSnippet}
-      />
-    )}
-  </div>
-);
+const Save = ({ attributes }) => {
+  refreshAffiliateWidgetsOnSave();
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <div {...useBlockProps.save()}>
+      {attributes?.productCarouselSnippet && (
+        <ProductCarousel
+          productCarouselEditURL={attributes.productCarouselEditURL}
+          productCarouselSnippet={attributes.productCarouselSnippet}
+        />
+      )}
+    </div>
+  );
+};
 
 Save.propTypes = {
   attributes: AttributesType.isRequired,

--- a/src/blocks/affiliate/shared/WidgetToolbar.jsx
+++ b/src/blocks/affiliate/shared/WidgetToolbar.jsx
@@ -1,0 +1,31 @@
+import { IconButton, Toolbar } from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+import { refreshAffiliateWidgetsOnEdit } from './helpers';
+
+const WidgetToolbar = ({
+  onEdit,
+}) => {
+  return (
+    <Toolbar>
+      <>
+        <IconButton
+          icon="edit"
+          label="Edit product carousel"
+          onClick={onEdit}
+        />
+        <IconButton
+          icon="update"
+          label="Refresh display"
+          onClick={refreshAffiliateWidgetsOnEdit}
+        />
+      </>
+    </Toolbar>
+  );
+};
+
+WidgetToolbar.propTypes = {
+  onEdit: PropTypes.func.isRequired,
+};
+
+export default WidgetToolbar;

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -1,5 +1,7 @@
 export const refreshAffiliateWidgets = () => {
-  window.organic ||= {};
-  window.organic.cmd ||= [];
-  window.organic.cmd.push(({ affiliate }) => affiliate?.processPage());
+  setTimeout(() => {
+    window.organic ||= {};
+    window.organic.cmd ||= [];
+    window.organic.cmd.push(({ affiliate }) => affiliate?.processPage());
+  }, 0);
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -4,9 +4,8 @@ import { select, subscribe } from '@wordpress/data';
 async function whenEditorIsReady() {
   return new Promise((resolve) => {
     const unsubscribe = subscribe(() => {
-      // This will trigger after the initial render blocking, before the window load event
-      // This seems currently more reliable than using __unstableIsEditorReady
-      if (select('core/editor').isCleanNewPost() || select('core/block-editor').getBlockCount() > 0) {
+      // eslint-disable-next-line no-underscore-dangle
+      if (select('core/editor').__unstableIsEditorReady()) {
         unsubscribe();
         resolve();
       }
@@ -28,8 +27,13 @@ export const refreshAffiliateWidgetsOnEdit = () => {
 
 export const refreshAffiliateWidgetsOnSave = () => {
   whenEditorIsReady().then(() => {
-    if (!window.wp_organic_affiliate_processed) {
-      window.wp_organic_affiliate_processed = true;
+    // This will be called by all affiliate widgets on the page,
+    // so we put a check here to only refresh the widgets once.
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (!window.__wpOrganicAffiliateProcessed) {
+      // eslint-disable-next-line no-underscore-dangle
+      window.__wpOrganicAffiliateProcessed = true;
       refreshAffiliateWidgets();
     }
   });

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -25,7 +25,12 @@ export const refreshAffiliateWidgetsOnEdit = () => {
 };
 
 export const refreshAffiliateWidgetsOnSave = () => {
+  // Ideally, we wait for the Gutenberg editor to "be ready" and then refresh the display,
+  // rendering our widget divs as iframed content. However, this has been difficult to
+  // get working across browsers and WP environments.
+  // TODO: Improve this!
   const refreshWidgetsIfNecessary = () => {
+    // Each widget on the page will call this, so we put a check to only refresh once.
     // eslint-disable-next-line no-underscore-dangle
     if (!window.__wpOrganicAffiliateProcessed) {
       // eslint-disable-next-line no-underscore-dangle
@@ -35,5 +40,6 @@ export const refreshAffiliateWidgetsOnSave = () => {
   };
   // A hacky backup in case whenEditorIsReady fails.
   setTimeout(() => refreshWidgetsIfNecessary(), 2000);
+  // The below seems to work consistently Chromium browsers.
   whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -34,6 +34,6 @@ export const refreshAffiliateWidgetsOnSave = () => {
     }
   };
   // A hacky backup in case whenEditorIsReady fails.
-  setTimeout(() => refreshWidgetsIfNecessary(), 500);
+  setTimeout(() => refreshWidgetsIfNecessary(), 2000);
   whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -1,7 +1,40 @@
-export const refreshAffiliateWidgets = () => {
+import { select, subscribe } from '@wordpress/data';
+
+// See https://gist.github.com/KevinBatdorf/fca19e1f3b749b5c57db8158f4850eff
+async function whenEditorIsReady() {
+  return new Promise((resolve) => {
+    const unsubscribe = subscribe(() => {
+      // This will trigger after the initial render blocking, before the window load event
+      // This seems currently more reliable than using __unstableIsEditorReady
+      if (select('core/editor').isCleanNewPost() || select('core/block-editor').getBlockCount() > 0) {
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+const refreshAffiliateWidgets = () => {
   setTimeout(() => {
     window.organic ||= {};
     window.organic.cmd ||= [];
     window.organic.cmd.push(({ affiliate }) => affiliate?.processPage());
   }, 0);
+};
+
+export const refreshAffiliateWidgetsOnEdit = () => {
+  refreshAffiliateWidgets();
+};
+
+export const refreshAffiliateWidgetsOnSave = () => {
+  whenEditorIsReady().then(() => {
+    window.organic.cmd.push((apps) => {
+      const affiliate = { apps };
+      if (!affiliate || !affiliate.isEnabled()) return;
+      if (!affiliate.wp_processed) {
+        affiliate.wp_processed = true;
+        refreshAffiliateWidgets();
+      }
+    });
+  });
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -33,7 +33,7 @@ export const refreshAffiliateWidgetsOnSave = () => {
       refreshAffiliateWidgets();
     }
   };
-  whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
   // A hacky backup in case whenEditorIsReady fails.
-  setTimeout(() => refreshWidgetsIfNecessary(), 5000);
+  setTimeout(() => refreshWidgetsIfNecessary(), 500);
+  whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -25,10 +25,6 @@ export const refreshAffiliateWidgetsOnEdit = () => {
 };
 
 export const refreshAffiliateWidgetsOnSave = () => {
-  // Ideally, we wait for the Gutenberg editor to "be ready" and then refresh the display,
-  // rendering our widget divs as iframed content. However, this has been difficult to
-  // get working across browsers and WP environments.
-  // TODO: Improve this!
   const refreshWidgetsIfNecessary = () => {
     // Each widget on the page will call this, so we put a check to only refresh once.
     // eslint-disable-next-line no-underscore-dangle
@@ -38,8 +34,6 @@ export const refreshAffiliateWidgetsOnSave = () => {
       refreshAffiliateWidgets();
     }
   };
-  // A hacky backup in case whenEditorIsReady fails.
-  setTimeout(() => refreshWidgetsIfNecessary(), 2000);
   // The below seems to work consistently Chromium browsers.
   whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -34,6 +34,5 @@ export const refreshAffiliateWidgetsOnSave = () => {
       refreshAffiliateWidgets();
     }
   };
-  // The below seems to work consistently Chromium browsers.
   whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -28,13 +28,9 @@ export const refreshAffiliateWidgetsOnEdit = () => {
 
 export const refreshAffiliateWidgetsOnSave = () => {
   whenEditorIsReady().then(() => {
-    window.organic.cmd.push((apps) => {
-      const affiliate = { apps };
-      if (!affiliate || !affiliate.isEnabled()) return;
-      if (!affiliate.wp_processed) {
-        affiliate.wp_processed = true;
-        refreshAffiliateWidgets();
-      }
-    });
+    if (!window.wp_organic_affiliate_processed) {
+      window.wp_organic_affiliate_processed = true;
+      refreshAffiliateWidgets();
+    }
   });
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -18,7 +18,7 @@ const refreshAffiliateWidgets = () => {
     window.organic ||= {};
     window.organic.cmd ||= [];
     window.organic.cmd.push(({ affiliate }) => affiliate?.processPage());
-  }, 0);
+  }, 500);
 };
 
 export const refreshAffiliateWidgetsOnEdit = () => {

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -35,5 +35,5 @@ export const refreshAffiliateWidgetsOnSave = () => {
   };
   whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
   // A hacky backup in case whenEditorIsReady fails.
-  setTimeout(() => refreshWidgetsIfNecessary(), 500);
+  setTimeout(() => refreshWidgetsIfNecessary(), 5000);
 };

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -4,8 +4,7 @@ import { select, subscribe } from '@wordpress/data';
 async function whenEditorIsReady() {
   return new Promise((resolve) => {
     const unsubscribe = subscribe(() => {
-      // eslint-disable-next-line no-underscore-dangle
-      if (select('core/editor').__unstableIsEditorReady()) {
+      if (select('core/editor').isCleanNewPost() || select('core/block-editor').getBlockCount() > 0) {
         unsubscribe();
         resolve();
       }

--- a/src/blocks/affiliate/shared/helpers.js
+++ b/src/blocks/affiliate/shared/helpers.js
@@ -17,7 +17,7 @@ const refreshAffiliateWidgets = () => {
     window.organic ||= {};
     window.organic.cmd ||= [];
     window.organic.cmd.push(({ affiliate }) => affiliate?.processPage());
-  }, 500);
+  }, 0);
 };
 
 export const refreshAffiliateWidgetsOnEdit = () => {
@@ -25,15 +25,15 @@ export const refreshAffiliateWidgetsOnEdit = () => {
 };
 
 export const refreshAffiliateWidgetsOnSave = () => {
-  whenEditorIsReady().then(() => {
-    // This will be called by all affiliate widgets on the page,
-    // so we put a check here to only refresh the widgets once.
-
+  const refreshWidgetsIfNecessary = () => {
     // eslint-disable-next-line no-underscore-dangle
     if (!window.__wpOrganicAffiliateProcessed) {
       // eslint-disable-next-line no-underscore-dangle
       window.__wpOrganicAffiliateProcessed = true;
       refreshAffiliateWidgets();
     }
-  });
+  };
+  whenEditorIsReady().then(() => refreshWidgetsIfNecessary());
+  // A hacky backup in case whenEditorIsReady fails.
+  setTimeout(() => refreshWidgetsIfNecessary(), 500);
 };


### PR DESCRIPTION
Somehow the `pageshow` event is being triggered too early in some cases; setting a higher timeout fixed the issue, but that's obviously a hack.

I feel doubtful about finding the "right" event to guarantee that WordPress has fully "loaded" if `pageshow` fails; instead, it feels safer to reference WordPress functionality directly. This alternative solution is based on https://gist.github.com/KevinBatdorf/fca19e1f3b749b5c57db8158f4850eff. (https://github.com/WordPress/gutenberg/issues/8379 was also helpful.)

https://github.com/orgnc/wordpress-plugin/assets/47676832/a43af454-3578-426a-96ff-b11d4e3abaee

