### PR TITLE
Add Admin SDK injection for "guides" post type

### DIFF
--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -397,8 +397,8 @@ class AdminSettings {
                 </p>
                 <fieldset>
                     <p>
-                        Which post types from your CMS should be treated as Content for synchronization with
-                        the Organic Platform and eligible for Ads to be injected?
+                        Which post types from your CMS should be treated as content for synchronization with
+                        the Organic Platform and as eligible for the Organic SDK to be loaded on?
                         <ul>
                             <?php $this->injectPostTypesList(); ?>
                         </ul>

--- a/src/Organic/PageInjection.php
+++ b/src/Organic/PageInjection.php
@@ -149,7 +149,7 @@ class PageInjection {
             return;
         }
         $pt = get_current_screen()->post_type;
-        if ( $pt != 'post' && $pt != 'page' ) {
+        if ( $pt != 'post' && $pt != 'page' && $pt != 'guides' ) {
             return;
         }
 

--- a/src/Organic/PageInjection.php
+++ b/src/Organic/PageInjection.php
@@ -149,7 +149,7 @@ class PageInjection {
             return;
         }
         $pt = get_current_screen()->post_type;
-        if ( $pt != 'post' && $pt != 'page' && $pt != 'guides' ) {
+        if ( ! in_array( $pt, $this->organic->getPostTypes() ) ) {
             return;
         }
 


### PR DESCRIPTION
Flying Mag looks like they use a custom post type (example URL: https://dev.flyingmag.com/wp-admin/edit.php?post_type=guides). Because of this, the SDK is not loaded on such posts: https://github.com/orgnc/wordpress-plugin/blob/296b81805f24a9a750129091071b43ffb70b85c9/src/Organic/PageInjection.php#L141-L154

This means that widgets are not loaded properly. (😭 not again!)

I've added the "guides" post type as a temporary workaround, and I've confirmed this resolves the issue on the Flying Mag dev site. But this probably shouldn't be hard-coded at all. I think we should just use similar logic as we do in the Admin Settings (e.g., https://github.com/orgnc/wordpress-/blob/296b81805f24a9a750129091071b43ffb70b85c9/src/Organic/AdminSettings.php#L512). I'm not sure we want a separate option, like "organic_admin_pages_eligible_for_sdk," or if we use the same option ("organic_post_types") and modify the description (which currently reads "Which post types from your CMS should be treated as Content for synchronization with the Organic Platform and eligible for Ads to be injected?") Happy to modify the PR in either of these ways, but I'd like to get the guides post type working soon!