### PR TITLE
Use correct versions of PHP and composer in GH-actions

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: php-actions/composer@v6
+      - uses: shivammathur/setup-php@v2
         with:
-          working_dir: src
-          php_version: "7.4"
-          php_extensions: zip
-          version: "2.5.5"
+          php-version: '7.4'
+          extensions: zip
+          tools: composer:2.5.5
+
+      - name: Install dependencies
+        run: cd src && composer install
 
       - name: Run PHPCS
         run: cd src && composer run lint

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    name: "Organic Ad Wordpress: Build Dev Release"
+    name: 'Organic Ad Wordpress: Build Dev Release'
     runs-on: ubuntu-latest
 
     env:
@@ -23,14 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: php-actions/composer@v6
+      - name: Setup PHP with composer
+        uses: shivammathur/setup-php@v2
         with:
-          working_dir: src
-          php_version: "7.4"
-          php_extensions: zip
-          version: "2.5.5"
-
+          php-version: '7.4'
+          extensions: zip
+          tools: composer:2.5.5
 
       # Create a packaged up zip file
       - name: Set Version Number & Build Zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,13 +28,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: php-actions/composer@v6
+      - name: Setup PHP with composer
+        uses: shivammathur/setup-php@v2
         with:
-          working_dir: src
-          php_version: "7.4"
-          php_extensions: zip
-          version: "2.5.5"
+          php-version: '7.4'
+          extensions: zip
+          tools: composer:2.5.5
 
       - name: Build plugin
         id: build-zip

--- a/src/composer.json
+++ b/src/composer.json
@@ -11,7 +11,7 @@
         "fluentdom/html5": "^2.0",
         "fluentdom/selectors-phpcss": "^2.0",
         "fluentdom/selectors-symfony": "^4.0",
-        "liborm85/composer-vendor-cleaner": "^1.7",
+        "liborm85/composer-vendor-cleaner": "1.7.1",
         "php-webdriver/webdriver": "^1.13.0",
         "sentry/sdk": "^3.3.0",
         "seravo/wp-custom-bulk-actions": "^0.1.4"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d3236390803a7998420b6508a0ddcee",
+    "content-hash": "d7a04ca60d30b8224557c7fe9354cd0e",
     "packages": [
         {
             "name": "carica/phpcss",
@@ -855,16 +855,16 @@
         },
         {
             "name": "liborm85/composer-vendor-cleaner",
-            "version": "1.7.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liborm85/composer-vendor-cleaner.git",
-                "reference": "e4ebaf2a65ac74fd4cc6dcf2b92e2f68cc4bb23c"
+                "reference": "3d0feeb847c764d6eed2d993041101efbac67dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liborm85/composer-vendor-cleaner/zipball/e4ebaf2a65ac74fd4cc6dcf2b92e2f68cc4bb23c",
-                "reference": "e4ebaf2a65ac74fd4cc6dcf2b92e2f68cc4bb23c",
+                "url": "https://api.github.com/repos/liborm85/composer-vendor-cleaner/zipball/3d0feeb847c764d6eed2d993041101efbac67dcc",
+                "reference": "3d0feeb847c764d6eed2d993041101efbac67dcc",
                 "shasum": ""
             },
             "require": {
@@ -911,7 +911,7 @@
                 "issues": "https://github.com/liborm85/composer-vendor-cleaner/issues",
                 "source": "https://github.com/liborm85/composer-vendor-cleaner"
             },
-            "time": "2022-07-29T12:33:34+00:00"
+            "time": "2023-06-02T14:36:46+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Install correct versions of PHP and composer globally

The previous approach used correct versions only during `composer install` step
https://github.com/php-actions/composer/issues/67#issuecomment-1005187924