### PR TITLE
Bugfix: config sync content sync

### DIFF
--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -315,7 +315,7 @@ class AdminSettings {
                             name="organic_amp_ads_enabled"
                             <?php echo $amp_ads_enabled ? 'checked' : ''; ?>
                         />
-                        AMP Intergation Enabled
+                        AMP Integration Enabled
                     </label>
                 </p>
                 <p>

--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -470,7 +470,7 @@ class AdminSettings {
                 <?php $this->injectEnvInfo( 'PLATFORM_URL', $this->organic->getPlatformUrl() ); ?>
                 <?php $this->injectEnvInfo( 'ADS_TXT_URL', $this->organic->getAdsTxtManager()->getAdsTxtUrl() ); ?>
                 <?php $this->injectEnvInfo( 'Next Content Sync', $contentSyncCron ? $contentSyncCron->format( DATE_ATOM ) : 'false' ); ?>
-                <?php $this->injectEnvInfo( 'Content Re-Sync Triggered At', $this->organic->getContentResyncStartedAt() ); ?>
+                <?php $this->injectEnvInfo( 'Content Re-Sync Triggered At', $this->organic->getContentResyncStartedAt()->format( DATE_ATOM ) ); ?>
                 <?php if ( ! $ads_txt_redirect ) { ?>
                     <p>
                         <label>

--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -210,9 +210,7 @@ class AdminSettings {
         $prefill_config = $this->organic->getPrefillConfig();
         $affiliate_config = [ 'publicDomain' => $this->organic->getAffiliateDomain() ];
 
-        $contentSyncCron = wp_next_scheduled( 'organic_cron_sync_content' ) ?
-            new \DateTimeImmutable( '@' . wp_next_scheduled( 'organic_cron_sync_content' ) ) :
-            false;
+        $contentSyncCron = \DateTimeImmutable::createFromFormat( 'U', wp_next_scheduled( 'organic_cron_sync_content' ) );
         ?>
         <div id="organic-settings-page" class="wrap">
             <div id="organic-notices">

--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -465,6 +465,7 @@ class AdminSettings {
                 <?php $this->injectEnvInfo( 'PREBID_URL', $this->organic->getAdsConfig()->getPrebidBuildUrl() ); ?>
                 <?php $this->injectEnvInfo( 'PLATFORM_URL', $this->organic->getPlatformUrl() ); ?>
                 <?php $this->injectEnvInfo( 'ADS_TXT_URL', $this->organic->getAdsTxtManager()->getAdsTxtUrl() ); ?>
+                <?php $this->injectEnvInfo( 'Content Re-Sync Started At', $this->organic->getContentResyncStartedAt() ); ?>
                 <?php if ( ! $ads_txt_redirect ) { ?>
                     <p>
                         <label>

--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -209,6 +209,10 @@ class AdminSettings {
         $amp_config = $this->organic->getAmpConfig();
         $prefill_config = $this->organic->getPrefillConfig();
         $affiliate_config = [ 'publicDomain' => $this->organic->getAffiliateDomain() ];
+
+        $contentSyncCron = wp_next_scheduled( 'organic_cron_sync_content' ) ?
+            new \DateTimeImmutable( '@' . wp_next_scheduled( 'organic_cron_sync_content' ) ) :
+            false;
         ?>
         <div id="organic-settings-page" class="wrap">
             <div id="organic-notices">
@@ -465,7 +469,8 @@ class AdminSettings {
                 <?php $this->injectEnvInfo( 'PREBID_URL', $this->organic->getAdsConfig()->getPrebidBuildUrl() ); ?>
                 <?php $this->injectEnvInfo( 'PLATFORM_URL', $this->organic->getPlatformUrl() ); ?>
                 <?php $this->injectEnvInfo( 'ADS_TXT_URL', $this->organic->getAdsTxtManager()->getAdsTxtUrl() ); ?>
-                <?php $this->injectEnvInfo( 'Content Re-Sync Started At', $this->organic->getContentResyncStartedAt() ); ?>
+                <?php $this->injectEnvInfo( 'Next Content Sync', $contentSyncCron ? $contentSyncCron->format( DATE_ATOM ) : 'false' ); ?>
+                <?php $this->injectEnvInfo( 'Content Re-Sync Triggered At', $this->organic->getContentResyncStartedAt() ); ?>
                 <?php if ( ! $ads_txt_redirect ) { ?>
                     <p>
                         <label>

--- a/src/Organic/ContentSyncCommand.php
+++ b/src/Organic/ContentSyncCommand.php
@@ -39,7 +39,9 @@ class ContentSyncCommand {
      * Wrapper for __invoke with no args to make it cron friendly
      */
     public function run() {
-         $this->__invoke( [], [] );
+        $this->organic->info( 'organic_cron_sync_content starting...' );
+        $this->__invoke( [], [] );
+        $this->organic->info( 'organic_cron_sync_content completed' );
     }
 
     /**
@@ -67,6 +69,7 @@ class ContentSyncCommand {
      * @since 0.1.0
      */
     public function __invoke( $args, $opts ) {
+        $this->organic->info( __CLASS__ . ' invoked', [ 'args' => $args, 'opts' => $opts ] );
         if ( ! $this->organic->isEnabledAndConfigured() ) {
             $this->organic->warning( 'Cannot sync articles without enabled integration with SDK API Key and Site ID' );
             return;
@@ -82,9 +85,12 @@ class ContentSyncCommand {
             return;
         }
 
+        $this->organic->info( 'Organic Sync ... categories' );
         $this->organic->syncCategories();
+
         $post_ids = array_filter( explode( ',', ( $opts['posts'] ?? '' ) ) );
         if ( count( $post_ids ) ) {
+            $this->organic->info( 'Organic Sync ... specific posts' );
             foreach ( $post_ids as $post_id ) {
                 $post = \WP_Post::get_instance( $post_id );
                 if ( ! $post ) {

--- a/src/Organic/ContentSyncCommand.php
+++ b/src/Organic/ContentSyncCommand.php
@@ -69,7 +69,10 @@ class ContentSyncCommand {
      * @since 0.1.0
      */
     public function __invoke( $args, $opts ) {
-        $this->organic->info( __CLASS__ . ' invoked', [ 'args' => $args, 'opts' => $opts ] );
+        $this->organic->info( __CLASS__ . ' invoked', [
+            'args' => $args,
+            'opts' => $opts
+        ] );
         if ( ! $this->organic->isEnabledAndConfigured() ) {
             $this->organic->warning( 'Cannot sync articles without enabled integration with SDK API Key and Site ID' );
             return;

--- a/src/Organic/ContentSyncCommand.php
+++ b/src/Organic/ContentSyncCommand.php
@@ -69,10 +69,13 @@ class ContentSyncCommand {
      * @since 0.1.0
      */
     public function __invoke( $args, $opts ) {
-        $this->organic->info( __CLASS__ . ' invoked', [
-            'args' => $args,
-            'opts' => $opts
-        ] );
+        $this->organic->info(
+            __CLASS__ . ' invoked',
+            [
+                'args' => $args,
+                'opts' => $opts,
+            ]
+        );
         if ( ! $this->organic->isEnabledAndConfigured() ) {
             $this->organic->warning( 'Cannot sync articles without enabled integration with SDK API Key and Site ID' );
             return;

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -1339,22 +1339,25 @@ class Organic {
     public function syncPluginConfig() {
         try {
             $config = $this->sdk->mutateAndQueryWordPressConfig( $this );
+            if ( empty( $config ) ) {
+                throw new \UnexpectedValueException( 'Empty response from sdk->mutateAndQueryWordPressConfig', 204 );
+            }
         } catch ( \Exception $e ) {
             self::captureException( $e );
             return [
                 'updated' => false,
             ];
         }
-        if ( ! empty( $config ) ) {
-            $sentryDSN = $config['sentryDsn'];
-            if ( ! empty( $sentryDSN ) ) {
-                $this->updateOption( 'organic::sentry_dsn', $sentryDSN, false );
-                $this->configureSentryForSite();
-            }
-            if ( true === $config['triggerContentResync'] ) {
-                $this->triggerContentResync();
-            }
+
+        $sentryDSN = $config['sentryDsn'];
+        if ( ! empty( $sentryDSN ) ) {
+            $this->updateOption( 'organic::sentry_dsn', $sentryDSN, false );
+            $this->configureSentryForSite();
         }
+        if ( true === $config['triggerContentResync'] ) {
+            $this->triggerContentResync();
+        }
+
         return [
             'updated' => true,
         ];

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -11,7 +11,6 @@ use WP_Post;
 use WP_Query;
 
 use function \get_user_by;
-use function Sentry\captureException;
 
 const CAMPAIGN_ASSET_META_KEY = 'empire_campaign_asset_guid';
 const GAM_ID_META_KEY = 'empire_gam_id';
@@ -814,7 +813,7 @@ class Organic {
         }
 
         $canonical = get_permalink( $post );
-        $edit_url = get_edit_post_link( $post );
+        $edit_url = \Organic\get_edit_post_link( $post );
 
         # In order to support non-standard post metadata, we have a filter for each attribute
         $external_id = \apply_filters( 'organic_post_id', $post->ID );

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -1342,20 +1342,20 @@ class Organic {
             if ( empty( $config ) ) {
                 throw new \UnexpectedValueException( 'Empty response from sdk->mutateAndQueryWordPressConfig', 204 );
             }
+
+            $sentryDSN = $config['sentryDsn'];
+            if ( ! empty( $sentryDSN ) ) {
+                $this->updateOption( 'organic::sentry_dsn', $sentryDSN, false );
+                $this->configureSentryForSite();
+            }
+            if ( true === $config['triggerContentResync'] ) {
+                $this->triggerContentResync();
+            }
         } catch ( \Exception $e ) {
             self::captureException( $e );
             return [
                 'updated' => false,
             ];
-        }
-
-        $sentryDSN = $config['sentryDsn'];
-        if ( ! empty( $sentryDSN ) ) {
-            $this->updateOption( 'organic::sentry_dsn', $sentryDSN, false );
-            $this->configureSentryForSite();
-        }
-        if ( true === $config['triggerContentResync'] ) {
-            $this->triggerContentResync();
         }
 
         return [

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -835,7 +835,7 @@ class Organic {
 
         $meta_description = get_the_excerpt( $post );
         if ( is_plugin_active( 'wordpress-seo/wp-seo.php' ) ) {
-            $meta_description = get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true );
+            $meta_description = get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true ) ?: $meta_description;
         }
         $meta_description = \apply_filters( 'organic_post_meta_description', $meta_description, $post->ID );
 

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -799,7 +799,7 @@ class Organic {
      * @param WP_Post $post
      * @return void|null
      */
-    public function syncPost( $post ) {
+    public function syncPost( WP_Post $post ) {
         if ( ! $this->isPostEligibleForSync( $post ) ) {
             $this->debug(
                 'Organic Sync: SKIPPED',
@@ -926,11 +926,11 @@ class Organic {
     /**
      * Helper function to actually execute sync calls to Organic Platform for posts
      *
-     * @param $posts
+     * @param WP_Post[] $posts
      * @return int # of posts sync-ed
      * @throws Exception
      */
-    private function _syncPosts( $posts ): int {
+    private function _syncPosts( array $posts ): int {
         $updated = 0;
         foreach ( $posts as $post ) {
             $this->syncPost( $post );

--- a/src/Organic/SDK/OrganicSdk.php
+++ b/src/Organic/SDK/OrganicSdk.php
@@ -191,22 +191,24 @@ class OrganicSdk {
         $mutation->setSelectionSet( [ 'ok', 'gamId' ] );
 
         $variables = [
-            'input' => array_filter( [
-                'authors' => $authors,
-                'canonicalUrl' => $canonicalUrl,
-                'categories' => $categories,
-                'content' => $content,
-                'externalId' => $externalId,
-                'modifiedDate' => $modifiedDate->format( DateTimeInterface::ATOM ),
-                'publishedDate' => $publishedDate->format( DateTimeInterface::ATOM ),
-                'siteGuid' => $this->siteGuid,
-                'tags' => $tags,
-                'title' => $title,
-                'campaignAssetGuid' => $campaign_asset_guid,
-                'editUrl' => $editUrl,
-                'featuredImageUrl' => $featured_image_url,
-                'metaDescription' => $meta_description,
-            ] ),
+            'input' => array_filter(
+                [
+                    'authors' => $authors,
+                    'canonicalUrl' => $canonicalUrl,
+                    'categories' => $categories,
+                    'content' => $content,
+                    'externalId' => $externalId,
+                    'modifiedDate' => $modifiedDate->format( DateTimeInterface::ATOM ),
+                    'publishedDate' => $publishedDate->format( DateTimeInterface::ATOM ),
+                    'siteGuid' => $this->siteGuid,
+                    'tags' => $tags,
+                    'title' => $title,
+                    'campaignAssetGuid' => $campaign_asset_guid,
+                    'editUrl' => $editUrl,
+                    'featuredImageUrl' => $featured_image_url,
+                    'metaDescription' => $meta_description,
+                ]
+            ),
         ];
 
         $result = $this->runQuery( $mutation, $variables );

--- a/src/Organic/SDK/OrganicSdk.php
+++ b/src/Organic/SDK/OrganicSdk.php
@@ -191,7 +191,7 @@ class OrganicSdk {
         $mutation->setSelectionSet( [ 'ok', 'gamId' ] );
 
         $variables = [
-            'input' => [
+            'input' => array_filter( [
                 'authors' => $authors,
                 'canonicalUrl' => $canonicalUrl,
                 'categories' => $categories,
@@ -206,7 +206,7 @@ class OrganicSdk {
                 'editUrl' => $editUrl,
                 'featuredImageUrl' => $featured_image_url,
                 'metaDescription' => $meta_description,
-            ],
+            ] ),
         ];
 
         $result = $this->runQuery( $mutation, $variables );

--- a/src/Organic/SDK/OrganicSdk.php
+++ b/src/Organic/SDK/OrganicSdk.php
@@ -502,7 +502,7 @@ class OrganicSdk {
      */
     public function mutateAndQueryWordPressConfig( \Organic\Organic $organic ) {
         global $wp_version;
-        $mutation = ( new Mutation( 'syncWordpressPluginConfig' ) );
+        $mutation = new Mutation( 'syncWordpressPluginConfig' );
         $mutation->setVariables( [ new Variable( 'configInput', 'WordpressPluginConfigInput', true ) ] );
         $mutation->setArguments( [ 'configInput' => '$configInput' ] );
         $mutation->setSelectionSet(
@@ -536,7 +536,7 @@ class OrganicSdk {
         ];
 
         $result = $this->runQuery( $mutation, $variables );
-        return $result['data']['config'];
+        return $result['data']['syncWordpressPluginConfig']['config'];
     }
 
     /**

--- a/src/Organic/helpers.php
+++ b/src/Organic/helpers.php
@@ -37,7 +37,7 @@ function is_valid_uuid( string $uuid ) {
  * @return string|null|void    The edit post link for the given post. Null if the post type does not
  *                             exist or does not allow an editing UI.
  */
-function get_edit_post_link($id = 0, string $context = 'display' ) {
+function get_edit_post_link( $id = 0, string $context = 'display' ) {
     $post = get_post( $id );
     if ( ! $post ) {
         return;

--- a/src/Organic/helpers.php
+++ b/src/Organic/helpers.php
@@ -2,6 +2,8 @@
 
 namespace Organic;
 
+use WP_Post;
+
 /**
  * Determine whether this is an AMP response.
  *
@@ -24,4 +26,39 @@ function is_valid_uuid( string $uuid ) {
     return is_string( $uuid )
         ? preg_match( '/^[a-f\d]{8}(-[a-f\d]{4}){4}[a-f\d]{8}$/i', $uuid ) === 1
         : false;
+}
+
+/**
+ * Copy of the WordPress `get_edit_post_link` function without a permission check
+ *
+ * @param WP_Post|int $id
+ * @param string $context
+ * @return mixed|void|null
+ */
+function get_edit_post_link($id = 0, string $context = 'display' ) {
+    $post = get_post( $id );
+    if ( ! $post ) {
+        return;
+    }
+
+    if ( 'revision' === $post->post_type ) {
+        $action = '';
+    } elseif ( 'display' === $context ) {
+        $action = '&amp;action=edit';
+    } else {
+        $action = '&action=edit';
+    }
+
+    $post_type_object = get_post_type_object( $post->post_type );
+    if ( ! $post_type_object ) {
+        return;
+    }
+
+    if ( $post_type_object->_edit_link ) {
+        $link = admin_url( sprintf( $post_type_object->_edit_link . $action, $post->ID ) );
+    } else {
+        $link = '';
+    }
+
+    return apply_filters( 'get_edit_post_link', $link, $post->ID, $context );
 }

--- a/src/Organic/helpers.php
+++ b/src/Organic/helpers.php
@@ -29,11 +29,13 @@ function is_valid_uuid( string $uuid ) {
 }
 
 /**
- * Copy of the WordPress `get_edit_post_link` function without a permission check
+ * Copy of the built-in WordPress function `get_edit_post_link`.
+ * Retrieves the edit post link for post without a permissions check.
  *
- * @param WP_Post|int $id
- * @param string $context
- * @return mixed|void|null
+ * @param int|WP_Post $id      Optional. Post ID or post object. Default is the global `$post`.
+ * @param string      $context Optional. How to output the '&' character. Default '&amp;'.
+ * @return string|null|void    The edit post link for the given post. Null if the post type does not
+ *                             exist or does not allow an editing UI.
  */
 function get_edit_post_link($id = 0, string $context = 'display' ) {
     $post = get_post( $id );


### PR DESCRIPTION
The primary issue fixed here is the OrganicSDK. We were previously missing an intermediary array key for `syncWordpressPluginConfig` which is now included.

Through the course of debugging this issue, I added some minor code restructuring that I'm leaving in this PR with other minor fixes/optimizations.