### PR TITLE
Bugfix/config sync content sync

### DIFF
--- a/src/Organic/AdminSettings.php
+++ b/src/Organic/AdminSettings.php
@@ -210,7 +210,7 @@ class AdminSettings {
         $prefill_config = $this->organic->getPrefillConfig();
         $affiliate_config = [ 'publicDomain' => $this->organic->getAffiliateDomain() ];
 
-        $contentSyncCron = \DateTimeImmutable::createFromFormat( 'U', wp_next_scheduled( 'organic_cron_sync_content' ) );
+        $contentSyncCron = \DateTimeImmutable::createFromFormat( 'U', wp_next_scheduled( 'organic_cron_sync_content' ), wp_timezone() );
         ?>
         <div id="organic-settings-page" class="wrap">
             <div id="organic-notices">

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -799,7 +799,6 @@ class Organic {
      * @return void|null
      */
     public function syncPost( WP_Post $post ) {
-        wp_cache_flush();
         if ( ! $this->isPostEligibleForSync( $post ) ) {
             $this->debug(
                 'Organic Sync: SKIPPED',
@@ -1097,6 +1096,7 @@ class Organic {
     }
 
     public function triggerContentResync(): DateTimeImmutable {
+        wp_cache_flush();
         if ( false === $this->contentResyncTriggeredRecently() ) {
             global $wpdb;
             $wpdb->get_results(
@@ -1107,6 +1107,7 @@ class Organic {
             );
             $this->updateContentResyncStartedAt();
         }
+        wp_cache_flush();
         return $this->getContentResyncStartedAt();
     }
 

--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -799,6 +799,7 @@ class Organic {
      * @return void|null
      */
     public function syncPost( WP_Post $post ) {
+        wp_cache_flush();
         if ( ! $this->isPostEligibleForSync( $post ) ) {
             $this->debug(
                 'Organic Sync: SKIPPED',


### PR DESCRIPTION
We've been able to trace the issue to what I believe to be some aggressive caching options on certain Wordpress installs. Calls to `update_post_meta` and `get_post_meta` are always returning a cached value. I can understand the `get_post_meta`, but `update_post_meta` is a volatile action and shouldn't be cached here.

To get around this, I can run `delete_post_meta`, but then the original `WP_Query` is cached still so we keep processing the same posts over and over again (needlessly). The only way I've been able to get it to work properly, consistently is running `wp_flush_cache()`. However, this seems quite aggressive from my perspective.

I also tried `wp_cache_delete` to target the individual items, but since I'm not setting them into the cache, I can't reliably delete them from the cache.

Side note… one specific Wordpress installation does seem to be using a pretty old version of the [Redis cache](https://github.com/rhubarbgroup/redis-cache/releases).

Original [conversation](https://organicventures.slack.com/archives/C01E3N5BF53/p1689795530205229?thread_ts=1689258698.881069&cid=C01E3N5BF53) happening in Slack.