### PR TITLE
Fixes appeared deprecation warnings using PHP-8.2

### DIFF
--- a/src/Organic/Organic.php
+++ b/src/Organic/Organic.php
@@ -20,6 +20,7 @@ const SYNC_META_KEY = 'empire_sync';
 /**
  * Client Plugin for the Organic Platform
  */
+#[\AllowDynamicProperties]
 class Organic {
     public $version = \Organic\ORGANIC_PLUGIN_VERSION;
 

--- a/src/Organic/types.php
+++ b/src/Organic/types.php
@@ -14,10 +14,10 @@ class AMP_BREAKPOINT {
     const XL = 1200;
 
     public static function minWidth( int $size ) {
-        return "(min-width: ${size}px)";
+        return "(min-width: {$size}px)";
     }
 
     public static function maxWidth( int $size ) {
-        return "(max-width: ${size}px)";
+        return "(max-width: {$size}px)";
     }
 }


### PR DESCRIPTION
Fixed warning examples:
```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/web/app/mu-plugins/wordpress-plugin/Organic/types.php on line 17
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /var/www/html/web/app/mu-plugins/wordpress-plugin/Organic/types.php on line 21
Deprecated: Creation of dynamic property Organic\Organic::$siteDomain is deprecated in /var/www/html/web/app/mu-plugins/wordpress-plugin/Organic/Organic.php on line 241
Deprecated: Creation of dynamic property Organic\Organic::$ampEnabled is deprecated in /var/www/html/web/app/mu-plugins/wordpress-plugin/Organic/Organic.php on line 254
Deprecated: Creation of dynamic property Organic\Organic::$prefillEnabled is deprecated in /var/www/html/web/app/mu-plugins/wordpress-plugin/Organic/Organic.php on line 256
```