### PR TITLE
EP-6140: Fix Organic Affiliate modal height issue

### DIFF
--- a/src/blocks/affiliate/shared/integrationModal.scss
+++ b/src/blocks/affiliate/shared/integrationModal.scss
@@ -1,9 +1,12 @@
 .integration-modal {
   .components-modal__content {
     padding: 0;
-
     &::before {
       margin: 0;
+    }
+    /* fixes an issue where an extraneous div in the modal content prevents the iframe from spanning full height */
+    > div:not(.components-modal__header) {
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue where the Organic Affiliate WP modal contains an extraneous `<div>` that prevents the iframe from spanning 100% height, thus rendering it unusable.